### PR TITLE
Fix poster dropdown layering and card image clipping

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -89,6 +89,11 @@ body {
 /* Hide/Show by filter */
 .item-card-wrapper.hidden { display: none !important; }
 
+/* Keep batch action menus above the poster grid below them. */
+.automatic-batch-row { position: relative; z-index: 20; }
+.automatic-batch-card { position: relative; }
+#itemsGrid { position: relative; z-index: 1; }
+
 /* Selected counter */
 #selectedCount { font-weight: 600; color: var(--primary-color); }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,7 +71,7 @@ body {
 
 /* Poster containers */
 .card-img-top-wrapper { position: relative; height: 280px; overflow: hidden; border-radius: calc(var(--border-radius) - 1px) calc(var(--border-radius) - 1px) 0 0; background-color: var(--surface-muted); }
-.jellyfin-poster-large { width: 100%; height: 100%; object-fit: contain; object-position: center; transition: transform 0.3s ease; background-color: var(--surface-muted); }
+.jellyfin-poster-large { width: 100%; height: 100%; object-fit: cover; object-position: center; transition: transform 0.3s ease; background-color: var(--surface-muted); }
 .jellyfin-poster-placeholder-large { width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; background-color: var(--surface-muted); color: var(--muted-color); font-size: 2rem; border: 2px dashed var(--border-color); }
 .jellyfin-poster-placeholder-large small { font-size: 0.75rem; margin-top: 0.5rem; }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -70,7 +70,7 @@ body {
 .btn-outline-secondary:hover { background-color: var(--muted-color); border-color: var(--muted-color); color: white; }
 
 /* Poster containers */
-.card-img-top-wrapper { position: relative; height: 280px; overflow: hidden; border-radius: 0.375rem 0.375rem 0 0; background-color: var(--surface-muted); }
+.card-img-top-wrapper { position: relative; height: 280px; overflow: hidden; border-radius: calc(var(--border-radius) - 1px) calc(var(--border-radius) - 1px) 0 0; background-color: var(--surface-muted); }
 .jellyfin-poster-large { width: 100%; height: 100%; object-fit: contain; object-position: center; transition: transform 0.3s ease; background-color: var(--surface-muted); }
 .jellyfin-poster-placeholder-large { width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; background-color: var(--surface-muted); color: var(--muted-color); font-size: 2rem; border: 2px dashed var(--border-color); }
 .jellyfin-poster-placeholder-large small { font-size: 0.75rem; margin-top: 0.5rem; }
@@ -81,7 +81,7 @@ body {
 .item-type-badge-series { background-color: rgba(123, 31, 162, 0.9); color: white; }
 
 /* Card hover effects */
-.item-card { transition: all 0.3s ease; border: 1px solid var(--border-color); background: var(--surface); }
+.item-card { transition: all 0.3s ease; border: 1px solid var(--border-color); background: var(--surface); overflow: hidden; }
 .item-card:hover { transform: translateY(-5px); box-shadow: var(--box-shadow-hover); border-color: var(--primary-color); }
 .item-card:hover .jellyfin-poster-large { transform: scale(1.02); }
 .item-card.selected { border: 2px solid var(--success-color); box-shadow: 0 0 15px rgba(40, 167, 69, 0.3); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,9 +112,9 @@
 </div>
 
 <!-- Automatic Batch Operations -->
-<div class="row mb-4">
+<div class="row mb-4 automatic-batch-row">
     <div class="col-12">
-        <div class="card" style="position: relative;">
+        <div class="card automatic-batch-card">
             <div class="card-body py-3">
                 <div class="row align-items-center">
                     <div class="col-md-8">


### PR DESCRIPTION
Fixes #16

Fixes poster card layering and thumbnail framing issues in the main library grid.

- Ensures the Auto-Get Posters dropdown renders above the poster grid instead of behind the next row’s cover art.
- Clips poster card contents to the card border so hover scaling does not bleed outside rounded corners.
- Uses `object-fit: cover` for library poster thumbnails so poster frames stay consistently filled across browser zoom levels.