### PR TITLE
Add failed item tracking, live Auto-Get progress, and processed item markers

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,9 @@ user_sessions = {}
 selenium_ready_event = threading.Event()
 BATCH_DELAY_SEC = getattr(Config, 'TPDB_BATCH_DELAY_SEC', 1.5)
 FAILED_LOG_FILE = getattr(Config, 'FAILED_LOG_FILE', os.path.join(Config.LOG_DIR, 'failed.log'))
+RESULTS_LOG_FILE = getattr(Config, 'RESULTS_LOG_FILE', os.path.join(Config.LOG_DIR, 'results.log'))
+auto_batch_jobs = {}
+auto_batch_jobs_lock = threading.Lock()
 
 
 def _evict_stale_user_sessions(max_age_sec=7200):
@@ -71,14 +74,205 @@ def _sweep_stale_temp_posters(max_age_sec=3600):
         logging.info("Removed %d stale temp poster files.", removed_count)
 
 
+def _create_auto_batch_job(target_filter, skip_processed=False):
+    job_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat(timespec='seconds') + 'Z'
+    job = {
+        'job_id': job_id,
+        'filter': target_filter,
+        'skip_processed': skip_processed,
+        'status': 'starting',
+        'phase': 'starting',
+        'message': 'Starting automatic poster batch...',
+        'cancel_requested': False,
+        'current_item': None,
+        'current_item_id': None,
+        'current_item_type': None,
+        'current_item_year': None,
+        'old_poster_url': None,
+        'new_poster_url': None,
+        'total_items': 0,
+        'processed': 0,
+        'remaining': 0,
+        'successful': 0,
+        'failed': 0,
+        'results': [],
+        'done': False,
+        'success': None,
+        'error': None,
+        'created_at': now,
+        'updated_at': now,
+    }
+    with auto_batch_jobs_lock:
+        auto_batch_jobs[job_id] = job
+    return job_id
+
+
+def _update_auto_batch_job(job_id, **updates):
+    updates['updated_at'] = datetime.utcnow().isoformat(timespec='seconds') + 'Z'
+    with auto_batch_jobs_lock:
+        job = auto_batch_jobs.get(job_id)
+        if not job:
+            return
+        job.update(updates)
+        if 'processed' in updates or 'total_items' in updates:
+            job['remaining'] = max(job.get('total_items', 0) - job.get('processed', 0), 0)
+
+
+def _get_auto_batch_job(job_id):
+    with auto_batch_jobs_lock:
+        job = auto_batch_jobs.get(job_id)
+        if not job:
+            return None
+        snapshot = dict(job)
+        snapshot['results'] = list(job.get('results', []))
+        return snapshot
+
+
+def _is_auto_batch_cancelled(job_id):
+    with auto_batch_jobs_lock:
+        job = auto_batch_jobs.get(job_id)
+        return bool(job and job.get('cancel_requested'))
+
+
+def _cancel_auto_batch_job(job_id):
+    with auto_batch_jobs_lock:
+        job = auto_batch_jobs.get(job_id)
+        if not job:
+            return None
+        if job.get('done'):
+            return dict(job)
+        job['cancel_requested'] = True
+        job['status'] = 'cancelling'
+        job['phase'] = 'cancelling'
+        job['message'] = 'Cancelling after the current step...'
+        job['updated_at'] = datetime.utcnow().isoformat(timespec='seconds') + 'Z'
+        return dict(job)
+
+
+def _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count):
+    _update_auto_batch_job(
+        job_id,
+        status='cancelled',
+        phase='cancelled',
+        message='Automatic batch cancelled.',
+        current_item=None,
+        current_item_id=None,
+        old_poster_url=None,
+        new_poster_url=None,
+        results=list(results),
+        successful=successful_count,
+        failed=failed_count,
+        done=True,
+        success=False,
+        error='Cancelled by user',
+    )
+
+
 def _get_failed_log_path():
     return FAILED_LOG_FILE
+
+
+def _get_results_log_path():
+    return RESULTS_LOG_FILE
 
 
 def _write_failed_log_entry(entry):
     os.makedirs(Config.LOG_DIR, exist_ok=True)
     with open(_get_failed_log_path(), 'a', encoding='utf-8') as failed_log:
         failed_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
+def _write_results_log_entry(entry):
+    os.makedirs(Config.LOG_DIR, exist_ok=True)
+    with open(_get_results_log_path(), 'a', encoding='utf-8') as results_log:
+        results_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
+def _log_processed_item(item=None, operation='auto-poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
+    """Append one structured successful poster application entry to results.log."""
+    try:
+        resolved_item = item
+        resolved_item_id = item_id or (item or {}).get('id')
+        resolved_item_title = item_title or (item or {}).get('title') or 'Unknown'
+        resolved_item_type = item_type or (item or {}).get('type')
+        resolved_item_year = item_year if item_year is not None else (item or {}).get('year')
+        entry = {
+            'id': str(uuid.uuid4()),
+            'timestamp': datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+            'status': 'success',
+            'operation': operation,
+            'item_id': resolved_item_id,
+            'item_title': resolved_item_title,
+            'item_type': resolved_item_type,
+            'item_year': resolved_item_year,
+            'poster_url': poster_url,
+        }
+        _write_results_log_entry(entry)
+        _log_resolved_item(
+            resolved_item,
+            operation=operation,
+            poster_url=poster_url,
+            item_id=resolved_item_id,
+            item_title=resolved_item_title,
+            item_type=resolved_item_type,
+            item_year=resolved_item_year,
+        )
+    except Exception as results_log_error:
+        logging.warning(f"Failed to write processed item log: {results_log_error}")
+
+
+def _read_processed_item_ids():
+    results_log_path = _get_results_log_path()
+    if not os.path.exists(results_log_path):
+        return set()
+
+    processed_item_ids = set()
+    with open(results_log_path, 'r', encoding='utf-8') as results_log:
+        for line in results_log:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get('status') == 'success' and entry.get('item_id'):
+                processed_item_ids.add(entry['item_id'])
+
+    return processed_item_ids
+
+
+def _read_processed_items(limit=500):
+    results_log_path = _get_results_log_path()
+    if not os.path.exists(results_log_path):
+        return []
+
+    entries = []
+    with open(results_log_path, 'r', encoding='utf-8') as results_log:
+        for line in results_log:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get('status') == 'success':
+                entries.append(entry)
+
+    latest_entries = []
+    seen_item_ids = set()
+    for entry in reversed(entries):
+        item_id = entry.get('item_id')
+        if not item_id or item_id in seen_item_ids:
+            continue
+        seen_item_ids.add(item_id)
+        latest_entries.append(entry)
+        if len(latest_entries) >= limit:
+            break
+
+    return latest_entries
 
 
 def _log_failed_item(item=None, error=None, operation='poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
@@ -223,6 +417,7 @@ def _auto_fetch_and_upload_item(item, operation='retry-auto-poster'):
 
         upload_success = upload_image_to_jellyfin_improved(item_id, save_path)
         if upload_success:
+            _log_processed_item(item, operation=operation, poster_url=poster_url)
             return {
                 'item_id': item_id,
                 'item_title': item_title,
@@ -386,6 +581,7 @@ def upload_poster(item_id):
                 pass
 
             if success:
+                _log_processed_item(item, operation='manual-upload', poster_url=poster_url)
                 return jsonify({'success': True})
             else:
                 _log_failed_item(item, 'Failed to upload to Jellyfin', operation='manual-upload', poster_url=poster_url)
@@ -446,7 +642,9 @@ def upload_all_selected():
                     'error': None if success else 'Upload failed'
                 }
                 results.append(result)
-                if not success:
+                if success:
+                    _log_processed_item(item, operation='batch-upload', poster_url=poster_url)
+                else:
                     _log_failed_item(item, result['error'], operation='batch-upload', poster_url=poster_url)
             else:
                 _log_failed_item(item, 'Download failed', operation='batch-upload', poster_url=poster_url)
@@ -613,6 +811,349 @@ def debug_tpdb_search():
             'selenium_url': _get_selenium_current_url(),
         }), 500
 
+
+def _select_auto_batch_target_items(all_items, target_filter, skip_processed=False):
+    if target_filter == 'all':
+        target_items = all_items
+    elif target_filter == 'no-poster':
+        target_items = [item for item in all_items if not item.get('thumbnail_url')]
+    elif target_filter == 'movies':
+        target_items = [item for item in all_items if item.get('type') == 'Movie']
+    elif target_filter == 'series':
+        target_items = [item for item in all_items if item.get('type') == 'Series']
+    else:
+        target_items = []
+
+    # TEMP: constrain auto-poster runs for issue #18 testing.
+    test_titles = {'cowboy bebop', 'crash landing on you', 'claymore'}
+    target_items = [
+        item for item in all_items
+        if (item.get('title') or '').strip().lower() in test_titles
+    ]
+
+    if skip_processed:
+        processed_item_ids = _read_processed_item_ids()
+        target_items = [item for item in target_items if item.get('id') not in processed_item_ids]
+
+    return target_items
+
+
+def _run_auto_batch_job(job_id, target_filter, skip_processed=False):
+    results = []
+    successful_count = 0
+    failed_count = 0
+
+    try:
+        _update_auto_batch_job(job_id, status='running', phase='preparing', message='Preparing TPDB login...')
+        try:
+            if not selenium_driver:
+                setup_selenium_and_login()
+            logging.info("Selenium/TPDB login ready for auto-batch job.")
+        except Exception as e:
+            logging.error(f"Failed to setup Selenium/login to TPDB: {e}")
+            _update_auto_batch_job(
+                job_id,
+                status='failed',
+                phase='failed',
+                message='Failed to login to TPDB',
+                error=f'Failed to login to TPDB: {str(e)}',
+                done=True,
+                success=False,
+            )
+            return
+
+        _update_auto_batch_job(job_id, phase='loading', message='Loading Jellyfin items...')
+        all_items = get_jellyfin_items()
+        target_items = _select_auto_batch_target_items(all_items, target_filter, skip_processed=skip_processed)
+        total_items = len(target_items)
+        _update_auto_batch_job(
+            job_id,
+            total_items=total_items,
+            remaining=total_items,
+            message=f'Found {total_items} item(s) to process.',
+        )
+
+        if not target_items:
+            message = (
+                'No unprocessed items found matching the filter criteria.'
+                if skip_processed else
+                'No items found matching the filter criteria.'
+            )
+            _update_auto_batch_job(
+                job_id,
+                status='completed',
+                phase='completed',
+                message=message,
+                results=[],
+                done=True,
+                success=True,
+            )
+            return
+
+        logging.info(f"Processing {total_items} items for auto-poster job")
+        os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
+        _sweep_stale_temp_posters()
+
+        for i, item in enumerate(target_items):
+            if _is_auto_batch_cancelled(job_id):
+                _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
+                return
+
+            item_id = item.get('id', 'Unknown')
+            item_title = item.get('title', 'Unknown')
+            item_year = item.get('year')
+            item_type = item.get('type')
+            old_poster_url = item.get('thumbnail_url')
+            poster_url = None
+
+            try:
+                _update_auto_batch_job(
+                    job_id,
+                    status='running',
+                    phase='searching',
+                    current_item=item_title,
+                    current_item_id=item_id,
+                    current_item_type=item_type,
+                    current_item_year=item_year,
+                    old_poster_url=old_poster_url,
+                    new_poster_url=None,
+                    processed=i,
+                    successful=successful_count,
+                    failed=failed_count,
+                    message=f'Searching posters for {item_title}...',
+                )
+
+                logging.info(f"Processing item {i+1}/{total_items}: {item_title}")
+                posters = search_tpdb_for_posters_multiple(
+                    item_title,
+                    item_year,
+                    item_type,
+                    tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
+                    max_posters=1,
+                )
+
+                if _is_auto_batch_cancelled(job_id):
+                    _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
+                    return
+
+                if not posters:
+                    result = {
+                        'item_id': item_id,
+                        'item_title': item_title,
+                        'success': False,
+                        'error': 'No posters found',
+                        'old_poster_url': old_poster_url,
+                        'poster_url': None
+                    }
+                    _log_failed_item(item, result['error'], operation='auto-poster')
+                    results.append(result)
+                    failed_count += 1
+                    _update_auto_batch_job(
+                        job_id,
+                        phase='failed',
+                        processed=i + 1,
+                        failed=failed_count,
+                        results=list(results),
+                        message=f'No posters found for {item_title}.',
+                    )
+                    continue
+
+                poster_url = posters[0]['url']
+                safe_title = "".join(c for c in item_title if c.isalnum() or c in " _-").rstrip()
+                save_path = os.path.join(Config.TEMP_POSTER_DIR, f"auto_{safe_title}_{item_id}.jpg")
+
+                _update_auto_batch_job(
+                    job_id,
+                    phase='downloading',
+                    new_poster_url=poster_url,
+                    message=f'Downloading poster for {item_title}...'
+                )
+                if _is_auto_batch_cancelled(job_id):
+                    _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
+                    return
+
+                if download_image_with_cookies(poster_url, save_path):
+                    _update_auto_batch_job(job_id, phase='applying', message=f'Applying poster to {item_title}...')
+                    if _is_auto_batch_cancelled(job_id):
+                        _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
+                        return
+
+                    upload_success = upload_image_to_jellyfin_improved(item_id, save_path)
+
+                    try:
+                        if os.path.exists(save_path):
+                            os.remove(save_path)
+                    except Exception as cleanup_error:
+                        logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
+
+                    if upload_success:
+                        _log_processed_item(item, operation='auto-poster', poster_url=poster_url)
+                        result = {
+                            'item_id': item_id,
+                            'item_title': item_title,
+                            'success': True,
+                            'error': None,
+                            'old_poster_url': old_poster_url,
+                            'poster_url': poster_url
+                        }
+                        results.append(result)
+                        successful_count += 1
+                        logging.info(f"Successfully uploaded poster for: {item_title}")
+                        _update_auto_batch_job(
+                            job_id,
+                            phase='applied',
+                            processed=i + 1,
+                            successful=successful_count,
+                            results=list(results),
+                            message=f'Applied poster to {item_title}.',
+                        )
+                    else:
+                        result = {
+                            'item_id': item_id,
+                            'item_title': item_title,
+                            'success': False,
+                            'error': 'Failed to upload to Jellyfin',
+                            'old_poster_url': old_poster_url,
+                            'poster_url': poster_url
+                        }
+                        _log_failed_item(item, result['error'], operation='auto-poster', poster_url=poster_url)
+                        results.append(result)
+                        failed_count += 1
+                        _update_auto_batch_job(
+                            job_id,
+                            phase='failed',
+                            processed=i + 1,
+                            failed=failed_count,
+                            results=list(results),
+                            message=f'Failed to apply poster to {item_title}.',
+                        )
+                else:
+                    result = {
+                        'item_id': item_id,
+                        'item_title': item_title,
+                        'success': False,
+                        'error': 'Failed to download poster',
+                        'old_poster_url': old_poster_url,
+                        'poster_url': poster_url
+                    }
+                    _log_failed_item(item, result['error'], operation='auto-poster', poster_url=poster_url)
+                    results.append(result)
+                    failed_count += 1
+                    _update_auto_batch_job(
+                        job_id,
+                        phase='failed',
+                        processed=i + 1,
+                        failed=failed_count,
+                        results=list(results),
+                        message=f'Failed to download poster for {item_title}.',
+                    )
+            except TPDBRateLimited as e:
+                rate_limited_error = str(e)
+                logging.warning(f"TPDB rate-limit detected during batch job; aborting early: {rate_limited_error}")
+                result = {
+                    'item_id': item_id,
+                    'item_title': item_title,
+                    'success': False,
+                    'error': f'Aborted due to TPDB rate limit: {rate_limited_error}',
+                    'old_poster_url': old_poster_url,
+                    'poster_url': None
+                }
+                _log_failed_item(item, result['error'], operation='auto-poster')
+                results.append(result)
+                failed_count += 1
+                _update_auto_batch_job(
+                    job_id,
+                    status='failed',
+                    phase='rate_limited',
+                    processed=i + 1,
+                    failed=failed_count,
+                    results=list(results),
+                    message='Batch aborted due to TPDB rate limit.',
+                    error=result['error'],
+                    done=True,
+                    success=False,
+                )
+                return
+            except Exception as e:
+                logging.error(f"Error processing item {item_title}: {e}")
+                result = {
+                    'item_id': item_id,
+                    'item_title': item_title,
+                    'success': False,
+                    'error': str(e),
+                    'old_poster_url': old_poster_url,
+                    'poster_url': None
+                }
+                _log_failed_item(item, e, operation='auto-poster')
+                results.append(result)
+                failed_count += 1
+                _update_auto_batch_job(
+                    job_id,
+                    phase='failed',
+                    processed=i + 1,
+                    failed=failed_count,
+                    results=list(results),
+                    message=f'Failed processing {item_title}.',
+                )
+            finally:
+                time.sleep(BATCH_DELAY_SEC)
+
+        _update_auto_batch_job(
+            job_id,
+            status='completed',
+            phase='completed',
+            current_item=None,
+            processed=len(results),
+            successful=successful_count,
+            failed=failed_count,
+            results=list(results),
+            message=f'Batch completed: {successful_count} successful, {failed_count} failed.',
+            done=True,
+            success=True,
+        )
+    except Exception as e:
+        logging.error(f"Error in auto-batch job: {e}")
+        _update_auto_batch_job(
+            job_id,
+            status='failed',
+            phase='failed',
+            message='Automatic batch failed.',
+            error=str(e),
+            results=list(results),
+            successful=successful_count,
+            failed=failed_count,
+            done=True,
+            success=False,
+        )
+
+
+@app.route('/batch-auto-poster/start', methods=['POST'])
+def start_batch_auto_poster():
+    data = request.get_json() or {}
+    target_filter = data.get('filter', 'no-poster')
+    skip_processed = bool(data.get('skip_processed'))
+    job_id = _create_auto_batch_job(target_filter, skip_processed=skip_processed)
+    worker = threading.Thread(target=_run_auto_batch_job, args=(job_id, target_filter, skip_processed), daemon=True)
+    worker.start()
+    return jsonify({'success': True, 'job_id': job_id})
+
+
+@app.route('/batch-auto-poster/progress/<job_id>')
+def batch_auto_poster_progress(job_id):
+    job = _get_auto_batch_job(job_id)
+    if not job:
+        return jsonify({'success': False, 'error': 'Batch job not found'}), 404
+    return jsonify({'success': True, 'job': job})
+
+
+@app.route('/batch-auto-poster/cancel/<job_id>', methods=['POST'])
+def cancel_batch_auto_poster(job_id):
+    job = _cancel_auto_batch_job(job_id)
+    if not job:
+        return jsonify({'success': False, 'error': 'Batch job not found'}), 404
+    return jsonify({'success': True, 'job': job})
+
+
 @app.route('/batch-auto-poster', methods=['POST'])
 def batch_auto_poster():
     """
@@ -724,6 +1265,7 @@ def batch_auto_poster():
                         logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
 
                     if upload_success:
+                        _log_processed_item(item, operation='auto-poster', poster_url=poster_url)
                         results.append({
                             'item_id': item_id,
                             'item_title': item_title,
@@ -828,6 +1370,21 @@ def failed_items():
         })
     except Exception as e:
         logging.error(f"Error reading failed items log: {e}")
+        return jsonify({'items': [], 'error': str(e)}), 500
+
+
+@app.route('/processed-items')
+def processed_items():
+    """Return the most recent successful poster applications from results.log."""
+    limit = request.args.get('limit', default=500, type=int)
+    limit = max(1, min(limit, 1000))
+    try:
+        return jsonify({
+            'items': _read_processed_items(limit=limit),
+            'log_file': _get_results_log_path(),
+        })
+    except Exception as e:
+        logging.error(f"Error reading processed items log: {e}")
         return jsonify({'items': [], 'error': str(e)}), 500
 
 
@@ -992,6 +1549,7 @@ def upload_poster_direct():
                 logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
 
             if upload_success:
+                _log_processed_item(item, operation='direct-upload', poster_url=poster_url)
                 return jsonify({'success': True, 'message': 'Poster uploaded successfully'})
             else:
                 _log_failed_item(item, 'Failed to upload to Jellyfin', operation='direct-upload', poster_url=poster_url)

--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ logging.basicConfig(
 user_sessions = {}
 selenium_ready_event = threading.Event()
 BATCH_DELAY_SEC = getattr(Config, 'TPDB_BATCH_DELAY_SEC', 1.5)
+FAILED_LOG_FILE = getattr(Config, 'FAILED_LOG_FILE', os.path.join(Config.LOG_DIR, 'failed.log'))
 
 
 def _evict_stale_user_sessions(max_age_sec=7200):
@@ -68,6 +69,140 @@ def _sweep_stale_temp_posters(max_age_sec=3600):
             logging.warning(f"Failed to sweep stale temp file {file_path}: {cleanup_error}")
     if removed_count:
         logging.info("Removed %d stale temp poster files.", removed_count)
+
+
+def _get_failed_log_path():
+    return FAILED_LOG_FILE
+
+
+def _log_failed_item(item=None, error=None, operation='poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
+    """Append one structured failed item entry to failed.log."""
+    try:
+        os.makedirs(Config.LOG_DIR, exist_ok=True)
+        entry = {
+            'id': str(uuid.uuid4()),
+            'timestamp': datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+            'operation': operation,
+            'item_id': item_id or (item or {}).get('id'),
+            'item_title': item_title or (item or {}).get('title') or 'Unknown',
+            'item_type': item_type or (item or {}).get('type'),
+            'item_year': item_year if item_year is not None else (item or {}).get('year'),
+            'error': str(error or 'Unknown failure'),
+            'poster_url': poster_url,
+        }
+        with open(_get_failed_log_path(), 'a', encoding='utf-8') as failed_log:
+            failed_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
+    except Exception as failed_log_error:
+        logging.warning(f"Failed to write failed item log: {failed_log_error}")
+
+
+def _read_failed_items(limit=100):
+    failed_log_path = _get_failed_log_path()
+    if not os.path.exists(failed_log_path):
+        return []
+
+    entries = []
+    with open(failed_log_path, 'r', encoding='utf-8') as failed_log:
+        for line in failed_log:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                entries.append({
+                    'id': str(uuid.uuid4()),
+                    'timestamp': None,
+                    'operation': 'poster',
+                    'item_id': None,
+                    'item_title': 'Unknown',
+                    'item_type': None,
+                    'item_year': None,
+                    'error': line,
+                    'poster_url': None,
+                })
+
+    return list(reversed(entries[-limit:]))
+
+
+def _find_jellyfin_item(item_id):
+    if not item_id:
+        return None
+
+    session_id = session.get('session_id')
+    session_items = user_sessions.get(session_id, {}).get('items', [])
+    item = next((current_item for current_item in session_items if current_item.get('id') == item_id), None)
+    if item:
+        return item
+
+    return next((current_item for current_item in get_jellyfin_items() if current_item.get('id') == item_id), None)
+
+
+def _auto_fetch_and_upload_item(item):
+    item_id = item['id']
+    item_title = item['title']
+    posters = search_tpdb_for_posters_multiple(
+        item_title,
+        item.get('year'),
+        item.get('type'),
+        tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
+        max_posters=1,
+    )
+
+    if not posters:
+        error = 'No posters found'
+        _log_failed_item(item, error, operation='retry-auto-poster')
+        return {
+            'item_id': item_id,
+            'item_title': item_title,
+            'success': False,
+            'error': error,
+            'poster_url': None,
+        }
+
+    poster_url = posters[0]['url']
+    os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
+    _sweep_stale_temp_posters()
+    safe_title = "".join(c for c in item_title if c.isalnum() or c in " _-").rstrip()
+    save_path = os.path.join(Config.TEMP_POSTER_DIR, f"retry_{safe_title}_{item_id}.jpg")
+
+    try:
+        if not download_image_with_cookies(poster_url, save_path):
+            error = 'Failed to download poster'
+            _log_failed_item(item, error, operation='retry-auto-poster', poster_url=poster_url)
+            return {
+                'item_id': item_id,
+                'item_title': item_title,
+                'success': False,
+                'error': error,
+                'poster_url': poster_url,
+            }
+
+        upload_success = upload_image_to_jellyfin_improved(item_id, save_path)
+        if upload_success:
+            return {
+                'item_id': item_id,
+                'item_title': item_title,
+                'success': True,
+                'error': None,
+                'poster_url': poster_url,
+            }
+
+        error = 'Failed to upload to Jellyfin'
+        _log_failed_item(item, error, operation='retry-auto-poster', poster_url=poster_url)
+        return {
+            'item_id': item_id,
+            'item_title': item_title,
+            'success': False,
+            'error': error,
+            'poster_url': poster_url,
+        }
+    finally:
+        try:
+            if os.path.exists(save_path):
+                os.remove(save_path)
+        except Exception as cleanup_error:
+            logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
 
 @app.route('/')
 def index():
@@ -210,12 +345,15 @@ def upload_poster(item_id):
             if success:
                 return jsonify({'success': True})
             else:
+                _log_failed_item(item, 'Failed to upload to Jellyfin', operation='manual-upload', poster_url=poster_url)
                 return jsonify({'error': 'Failed to upload to Jellyfin'}), 500
         else:
+            _log_failed_item(item, 'Failed to download poster', operation='manual-upload', poster_url=poster_url)
             return jsonify({'error': 'Failed to download poster'}), 500
 
     except Exception as e:
         logging.error(f"Error uploading poster for {item_id}: {e}")
+        _log_failed_item(item, e, operation='manual-upload', poster_url=poster_url, item_id=item_id)
         return jsonify({'error': str(e)}), 500
 
 @app.route('/upload-all', methods=['POST'])
@@ -239,9 +377,11 @@ def upload_all_selected():
     _sweep_stale_temp_posters()
 
     for item_id, poster_url in selections.items():
+        item = None
         try:
             item = next((i for i in items if i['id'] == item_id), None)
             if not item:
+                _log_failed_item(error='Item not found', operation='batch-upload', poster_url=poster_url, item_id=item_id)
                 results.append({'item_id': item_id, 'success': False, 'error': 'Item not found'})
                 continue
 
@@ -256,13 +396,17 @@ def upload_all_selected():
                 except Exception:
                     pass
 
-                results.append({
+                result = {
                     'item_id': item_id,
                     'item_title': item['title'],
                     'success': success,
                     'error': None if success else 'Upload failed'
-                })
+                }
+                results.append(result)
+                if not success:
+                    _log_failed_item(item, result['error'], operation='batch-upload', poster_url=poster_url)
             else:
+                _log_failed_item(item, 'Download failed', operation='batch-upload', poster_url=poster_url)
                 results.append({
                     'item_id': item_id,
                     'item_title': item['title'],
@@ -271,9 +415,10 @@ def upload_all_selected():
                 })
 
         except Exception as e:
+            _log_failed_item(item, e, operation='batch-upload', poster_url=poster_url, item_id=item_id)
             results.append({
                 'item_id': item_id,
-                'item_title': item.get('title', 'Unknown'),
+                'item_title': item.get('title', 'Unknown') if item else 'Unknown',
                 'success': False,
                 'error': str(e)
             })
@@ -509,6 +654,7 @@ def batch_auto_poster():
                 )
 
                 if not posters:
+                    _log_failed_item(item, 'No posters found', operation='auto-poster')
                     results.append({
                         'item_id': item_id,
                         'item_title': item_title,
@@ -545,6 +691,7 @@ def batch_auto_poster():
                         successful_count += 1
                         logging.info(f"Successfully uploaded poster for: {item_title}")
                     else:
+                        _log_failed_item(item, 'Failed to upload to Jellyfin', operation='auto-poster', poster_url=poster_url)
                         results.append({
                             'item_id': item_id,
                             'item_title': item_title,
@@ -554,6 +701,7 @@ def batch_auto_poster():
                         })
                         failed_count += 1
                 else:
+                    _log_failed_item(item, 'Failed to download poster', operation='auto-poster', poster_url=poster_url)
                     results.append({
                         'item_id': item_id,
                         'item_title': item_title,
@@ -565,6 +713,7 @@ def batch_auto_poster():
             except TPDBRateLimited as e:
                 rate_limited_error = str(e)
                 logging.warning(f"TPDB rate-limit detected during batch; aborting early: {rate_limited_error}")
+                _log_failed_item(item, f'Aborted due to TPDB rate limit: {rate_limited_error}', operation='auto-poster')
                 results.append({
                     'item_id': item.get('id', 'Unknown'),
                     'item_title': item.get('title', 'Unknown'),
@@ -576,6 +725,7 @@ def batch_auto_poster():
                 break
             except Exception as e:
                 logging.error(f"Error processing item {item.get('title', 'Unknown')}: {e}")
+                _log_failed_item(item, e, operation='auto-poster')
                 results.append({
                     'item_id': item.get('id', 'Unknown'),
                     'item_title': item.get('title', 'Unknown'),
@@ -621,6 +771,104 @@ def batch_auto_poster():
             'successful': 0,
             'failed': 0
         }), 500
+
+
+@app.route('/failed-items')
+def failed_items():
+    """Return the most recent failed poster operations from failed.log."""
+    limit = request.args.get('limit', default=100, type=int)
+    limit = max(1, min(limit, 500))
+    try:
+        return jsonify({
+            'items': _read_failed_items(limit=limit),
+            'log_file': _get_failed_log_path(),
+        })
+    except Exception as e:
+        logging.error(f"Error reading failed items log: {e}")
+        return jsonify({'items': [], 'error': str(e)}), 500
+
+
+@app.route('/failed-items/retry', methods=['POST'])
+def retry_failed_item():
+    """Retry auto-fetching and uploading a poster for one failed item."""
+    if not selenium_ready_event.wait(timeout=30):
+        logging.error("Selenium not ready in time for /failed-items/retry")
+        return jsonify({'success': False, 'error': 'Backend service (Selenium) is not ready. Please try again in a moment.'}), 503
+
+    data = request.get_json() or {}
+    item_id = data.get('item_id')
+    if not item_id:
+        return jsonify({'success': False, 'error': 'Missing item_id'}), 400
+
+    try:
+        item = _find_jellyfin_item(item_id)
+        if not item:
+            _log_failed_item(error='Item not found', operation='retry-auto-poster', item_id=item_id)
+            return jsonify({'success': False, 'error': 'Item not found', 'item_id': item_id}), 404
+
+        result = _auto_fetch_and_upload_item(item)
+        return jsonify(result), 200 if result['success'] else 500
+    except TPDBRateLimited as e:
+        _log_failed_item(error=e, operation='retry-auto-poster', item_id=item_id)
+        return jsonify({'success': False, 'error': str(e), 'item_id': item_id}), 429
+    except Exception as e:
+        logging.error(f"Error retrying failed item {item_id}: {e}")
+        _log_failed_item(error=e, operation='retry-auto-poster', item_id=item_id)
+        return jsonify({'success': False, 'error': str(e), 'item_id': item_id}), 500
+
+
+@app.route('/failed-items/retry-all', methods=['POST'])
+def retry_all_failed_items():
+    """Retry auto-fetching and uploading posters for recent failed item IDs."""
+    if not selenium_ready_event.wait(timeout=30):
+        logging.error("Selenium not ready in time for /failed-items/retry-all")
+        return jsonify({'success': False, 'error': 'Backend service (Selenium) is not ready. Please try again in a moment.'}), 503
+
+    data = request.get_json() or {}
+    try:
+        limit = int(data.get('limit', 100))
+    except (TypeError, ValueError):
+        limit = 100
+    limit = max(1, min(limit, 500))
+    failed_entries = _read_failed_items(limit=limit)
+    item_ids = []
+    for entry in failed_entries:
+        item_id = entry.get('item_id')
+        if item_id and item_id not in item_ids:
+            item_ids.append(item_id)
+
+    results = []
+    for item_id in item_ids:
+        try:
+            item = _find_jellyfin_item(item_id)
+            if not item:
+                _log_failed_item(error='Item not found', operation='retry-all-auto-poster', item_id=item_id)
+                results.append({'item_id': item_id, 'success': False, 'error': 'Item not found'})
+                continue
+
+            result = _auto_fetch_and_upload_item(item)
+            results.append(result)
+        except TPDBRateLimited as e:
+            _log_failed_item(error=e, operation='retry-all-auto-poster', item_id=item_id)
+            results.append({'item_id': item_id, 'success': False, 'error': str(e)})
+            break
+        except Exception as e:
+            logging.error(f"Error retrying failed item {item_id}: {e}")
+            _log_failed_item(error=e, operation='retry-all-auto-poster', item_id=item_id)
+            results.append({'item_id': item_id, 'success': False, 'error': str(e)})
+        finally:
+            time.sleep(BATCH_DELAY_SEC)
+
+    successful_count = len([result for result in results if result.get('success')])
+    failed_count = len(results) - successful_count
+    return jsonify({
+        'success': failed_count == 0,
+        'results': results,
+        'processed': len(results),
+        'successful': successful_count,
+        'failed': failed_count,
+    })
+
 
 @app.route('/jellyfin-items')
 def jellyfin_items():
@@ -686,12 +934,15 @@ def upload_poster_direct():
             if upload_success:
                 return jsonify({'success': True, 'message': 'Poster uploaded successfully'})
             else:
+                _log_failed_item(item, 'Failed to upload to Jellyfin', operation='direct-upload', poster_url=poster_url)
                 return jsonify({'success': False, 'error': 'Failed to upload to Jellyfin'}), 500
         else:
+            _log_failed_item(item, 'Failed to download poster', operation='direct-upload', poster_url=poster_url)
             return jsonify({'success': False, 'error': 'Failed to download poster'}), 500
 
     except Exception as e:
         logging.error(f"Error uploading poster: {e}")
+        _log_failed_item(item if 'item' in locals() else None, e, operation='direct-upload', poster_url=poster_url if 'poster_url' in locals() else None, item_id=item_id if 'item_id' in locals() else None)
         return jsonify({'success': False, 'error': str(e)}), 500
 
 def create_placeholder_thumbnail():

--- a/app.py
+++ b/app.py
@@ -31,6 +31,14 @@ FAILED_LOG_FILE = getattr(Config, 'FAILED_LOG_FILE', os.path.join(Config.LOG_DIR
 RESULTS_LOG_FILE = getattr(Config, 'RESULTS_LOG_FILE', os.path.join(Config.LOG_DIR, 'results.log'))
 auto_batch_jobs = {}
 auto_batch_jobs_lock = threading.Lock()
+MAX_FINISHED_AUTO_BATCH_JOBS = 20
+
+
+def _prune_auto_batch_jobs():
+    # Caller must hold auto_batch_jobs_lock.
+    finished = [job_id for job_id, job in auto_batch_jobs.items() if job.get('done')]
+    for job_id in finished[:-MAX_FINISHED_AUTO_BATCH_JOBS]:
+        del auto_batch_jobs[job_id]
 
 
 def _evict_stale_user_sessions(max_age_sec=7200):
@@ -104,6 +112,7 @@ def _create_auto_batch_job(target_filter, skip_processed=False):
         'updated_at': now,
     }
     with auto_batch_jobs_lock:
+        _prune_auto_batch_jobs()
         auto_batch_jobs[job_id] = job
     return job_id
 
@@ -823,13 +832,6 @@ def _select_auto_batch_target_items(all_items, target_filter, skip_processed=Fal
         target_items = [item for item in all_items if item.get('type') == 'Series']
     else:
         target_items = []
-
-    # TEMP: constrain auto-poster runs for issue #18 testing.
-    test_titles = {'cowboy bebop', 'crash landing on you', 'claymore'}
-    target_items = [
-        item for item in all_items
-        if (item.get('title') or '').strip().lower() in test_titles
-    ]
 
     if skip_processed:
         processed_item_ids = _read_processed_item_ids()

--- a/app.py
+++ b/app.py
@@ -75,13 +75,19 @@ def _get_failed_log_path():
     return FAILED_LOG_FILE
 
 
+def _write_failed_log_entry(entry):
+    os.makedirs(Config.LOG_DIR, exist_ok=True)
+    with open(_get_failed_log_path(), 'a', encoding='utf-8') as failed_log:
+        failed_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
 def _log_failed_item(item=None, error=None, operation='poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
-    """Append one structured failed item entry to failed.log."""
+    """Append one structured active failure entry to failed.log."""
     try:
-        os.makedirs(Config.LOG_DIR, exist_ok=True)
         entry = {
             'id': str(uuid.uuid4()),
             'timestamp': datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+            'status': 'failed',
             'operation': operation,
             'item_id': item_id or (item or {}).get('id'),
             'item_title': item_title or (item or {}).get('title') or 'Unknown',
@@ -90,10 +96,29 @@ def _log_failed_item(item=None, error=None, operation='poster', poster_url=None,
             'error': str(error or 'Unknown failure'),
             'poster_url': poster_url,
         }
-        with open(_get_failed_log_path(), 'a', encoding='utf-8') as failed_log:
-            failed_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
+        _write_failed_log_entry(entry)
     except Exception as failed_log_error:
         logging.warning(f"Failed to write failed item log: {failed_log_error}")
+
+
+def _log_resolved_item(item=None, operation='retry-auto-poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
+    """Append a resolution marker so old failures stay in the log but leave the UI."""
+    try:
+        entry = {
+            'id': str(uuid.uuid4()),
+            'timestamp': datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+            'status': 'resolved',
+            'operation': operation,
+            'item_id': item_id or (item or {}).get('id'),
+            'item_title': item_title or (item or {}).get('title') or 'Unknown',
+            'item_type': item_type or (item or {}).get('type'),
+            'item_year': item_year if item_year is not None else (item or {}).get('year'),
+            'error': None,
+            'poster_url': poster_url,
+        }
+        _write_failed_log_entry(entry)
+    except Exception as failed_log_error:
+        logging.warning(f"Failed to write resolved item log: {failed_log_error}")
 
 
 def _read_failed_items(limit=100):
@@ -113,6 +138,7 @@ def _read_failed_items(limit=100):
                 entries.append({
                     'id': str(uuid.uuid4()),
                     'timestamp': None,
+                    'status': 'failed',
                     'operation': 'poster',
                     'item_id': None,
                     'item_title': 'Unknown',
@@ -122,7 +148,24 @@ def _read_failed_items(limit=100):
                     'poster_url': None,
                 })
 
-    return list(reversed(entries[-limit:]))
+    latest_entries = []
+    seen_item_ids = set()
+    for entry in reversed(entries):
+        item_id = entry.get('item_id')
+        if item_id:
+            if item_id in seen_item_ids:
+                continue
+            seen_item_ids.add(item_id)
+            if entry.get('status', 'failed') != 'failed':
+                continue
+        elif entry.get('status', 'failed') != 'failed':
+            continue
+
+        latest_entries.append(entry)
+        if len(latest_entries) >= limit:
+            break
+
+    return latest_entries
 
 
 def _find_jellyfin_item(item_id):
@@ -138,7 +181,7 @@ def _find_jellyfin_item(item_id):
     return next((current_item for current_item in get_jellyfin_items() if current_item.get('id') == item_id), None)
 
 
-def _auto_fetch_and_upload_item(item):
+def _auto_fetch_and_upload_item(item, operation='retry-auto-poster'):
     item_id = item['id']
     item_title = item['title']
     posters = search_tpdb_for_posters_multiple(
@@ -151,7 +194,7 @@ def _auto_fetch_and_upload_item(item):
 
     if not posters:
         error = 'No posters found'
-        _log_failed_item(item, error, operation='retry-auto-poster')
+        _log_failed_item(item, error, operation=operation)
         return {
             'item_id': item_id,
             'item_title': item_title,
@@ -169,7 +212,7 @@ def _auto_fetch_and_upload_item(item):
     try:
         if not download_image_with_cookies(poster_url, save_path):
             error = 'Failed to download poster'
-            _log_failed_item(item, error, operation='retry-auto-poster', poster_url=poster_url)
+            _log_failed_item(item, error, operation=operation, poster_url=poster_url)
             return {
                 'item_id': item_id,
                 'item_title': item_title,
@@ -189,7 +232,7 @@ def _auto_fetch_and_upload_item(item):
             }
 
         error = 'Failed to upload to Jellyfin'
-        _log_failed_item(item, error, operation='retry-auto-poster', poster_url=poster_url)
+        _log_failed_item(item, error, operation=operation, poster_url=poster_url)
         return {
             'item_id': item_id,
             'item_title': item_title,
@@ -788,6 +831,19 @@ def failed_items():
         return jsonify({'items': [], 'error': str(e)}), 500
 
 
+@app.route('/failed-items', methods=['DELETE'])
+def clear_failed_items():
+    """Clear failed.log after the user has reviewed failures."""
+    try:
+        os.makedirs(Config.LOG_DIR, exist_ok=True)
+        with open(_get_failed_log_path(), 'w', encoding='utf-8'):
+            pass
+        return jsonify({'success': True, 'items': []})
+    except Exception as e:
+        logging.error(f"Error clearing failed items log: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @app.route('/failed-items/retry', methods=['POST'])
 def retry_failed_item():
     """Retry auto-fetching and uploading a poster for one failed item."""
@@ -806,7 +862,9 @@ def retry_failed_item():
             _log_failed_item(error='Item not found', operation='retry-auto-poster', item_id=item_id)
             return jsonify({'success': False, 'error': 'Item not found', 'item_id': item_id}), 404
 
-        result = _auto_fetch_and_upload_item(item)
+        result = _auto_fetch_and_upload_item(item, operation='retry-auto-poster')
+        if result['success']:
+            _log_resolved_item(item, operation='retry-auto-poster', poster_url=result.get('poster_url'))
         return jsonify(result), 200 if result['success'] else 500
     except TPDBRateLimited as e:
         _log_failed_item(error=e, operation='retry-auto-poster', item_id=item_id)
@@ -846,7 +904,9 @@ def retry_all_failed_items():
                 results.append({'item_id': item_id, 'success': False, 'error': 'Item not found'})
                 continue
 
-            result = _auto_fetch_and_upload_item(item)
+            result = _auto_fetch_and_upload_item(item, operation='retry-all-auto-poster')
+            if result.get('success'):
+                _log_resolved_item(item, operation='retry-all-auto-poster', poster_url=result.get('poster_url'))
             results.append(result)
         except TPDBRateLimited as e:
             _log_failed_item(error=e, operation='retry-all-auto-poster', item_id=item_id)

--- a/config_example.py
+++ b/config_example.py
@@ -24,3 +24,4 @@ class Config:
     TPDB_DEBUG_SNAPSHOTS = True
     TEMP_POSTER_DIR = "temp_posters"
     LOG_DIR = "logs"
+    FAILED_LOG_FILE = os.path.join(LOG_DIR, "failed.log")

--- a/config_example.py
+++ b/config_example.py
@@ -25,3 +25,4 @@ class Config:
     TEMP_POSTER_DIR = "temp_posters"
     LOG_DIR = "logs"
     FAILED_LOG_FILE = os.path.join(LOG_DIR, "failed.log")
+    RESULTS_LOG_FILE = os.path.join(LOG_DIR, "results.log")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -85,10 +85,13 @@ body {
 .item-card:hover { transform: translateY(-5px); box-shadow: var(--box-shadow-hover); border-color: var(--primary-color); }
 .item-card:hover .jellyfin-poster-large { transform: scale(1.02); }
 .item-card.selected { border: 2px solid var(--success-color); box-shadow: 0 0 15px rgba(40, 167, 69, 0.3); }
+.item-card.processed-item { border-color: var(--success-color); box-shadow: 0 0 0 2px rgba(40, 167, 69, 0.18), var(--box-shadow); }
+.item-card.processed-item:hover { border-color: var(--success-color); box-shadow: 0 0 0 2px rgba(40, 167, 69, 0.28), var(--box-shadow-hover); }
 .item-card.failed-item { border-color: var(--danger-color); box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25), var(--box-shadow); }
 .item-card.failed-item:hover { border-color: var(--danger-color); box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.35), var(--box-shadow-hover); }
 .item-card.failed-item .find-posters-btn { border: 1px solid var(--danger-color); color: var(--danger-color); }
 .item-card.failed-item .find-posters-btn:hover { background-color: var(--danger-color); color: #fff; }
+.processed-item-overlay { position: absolute; top: 0.5rem; left: 0.5rem; z-index: 10; }
 .failed-item-overlay { position: absolute; top: 0.5rem; left: 0.5rem; z-index: 10; }
 .failed-card-focus { animation: failed-card-pulse 1.4s ease-out; }
 
@@ -102,6 +105,29 @@ body {
 
 /* Selected counter */
 #selectedCount { font-weight: 600; color: var(--primary-color); }
+#manualSelectionToolbarBtn.active #manualSelectionToolbarCount {
+    background-color: var(--primary-color) !important;
+    color: #fff;
+}
+
+/* Auto-batch progress */
+.auto-batch-progress {
+    border-top: 1px solid var(--border-color);
+    padding-top: 1rem;
+}
+.auto-batch-current-preview {
+    align-items: center;
+    background: var(--surface-muted);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-sm);
+    display: flex;
+    flex: 0 0 42px;
+    height: 56px;
+    justify-content: center;
+    overflow: hidden;
+    width: 42px;
+}
+.auto-batch-current-preview img { height: 100%; object-fit: cover; width: 100%; }
 
 /* Modals */
 .modal-dialog { max-width: 1200px; }
@@ -146,6 +172,13 @@ body {
 
 /* Tables in results modal */
 .results-table { color: var(--app-text); }
+.results-table > :not(caption) > * > * {
+    border-bottom-color: var(--border-color);
+    border-top-color: var(--border-color);
+}
+.results-table > :not(:first-child) {
+    border-top: 1px solid var(--border-color);
+}
 .results-table thead th { border-bottom: 1px solid var(--border-color); }
 .results-table tbody td { border-top: 1px solid var(--border-color); }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -85,6 +85,17 @@ body {
 .item-card:hover { transform: translateY(-5px); box-shadow: var(--box-shadow-hover); border-color: var(--primary-color); }
 .item-card:hover .jellyfin-poster-large { transform: scale(1.02); }
 .item-card.selected { border: 2px solid var(--success-color); box-shadow: 0 0 15px rgba(40, 167, 69, 0.3); }
+.item-card.failed-item { border-color: var(--danger-color); box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25), var(--box-shadow); }
+.item-card.failed-item:hover { border-color: var(--danger-color); box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.35), var(--box-shadow-hover); }
+.item-card.failed-item .find-posters-btn { border: 1px solid var(--danger-color); color: var(--danger-color); }
+.item-card.failed-item .find-posters-btn:hover { background-color: var(--danger-color); color: #fff; }
+.failed-item-overlay { position: absolute; top: 0.5rem; left: 0.5rem; z-index: 10; }
+.failed-card-focus { animation: failed-card-pulse 1.4s ease-out; }
+
+@keyframes failed-card-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(220, 53, 69, 0.65), var(--box-shadow-hover); }
+    100% { box-shadow: 0 0 0 12px rgba(220, 53, 69, 0), var(--box-shadow-hover); }
+}
 
 /* Hide/Show by filter */
 .item-card-wrapper.hidden { display: none !important; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -70,6 +70,12 @@ let posterModal = null;
 let resultsModal = null;
 let failedItemsPanelVisible = false;
 let activeFailedItemIds = new Set();
+let activeFailedItemDetails = new Map();
+let activeProcessedItemDetails = new Map();
+let autoBatchPollTimer = null;
+let currentAutoBatchJobId = null;
+let autoBatchStartedAt = null;
+let manualSelectionVisible = false;
 
 document.addEventListener('DOMContentLoaded', function() {
     // Theme first
@@ -91,6 +97,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize counters/buttons
     updateUploadAllButton();
     loadFailedItems();
+    loadProcessedItems();
 
     // If URL has filter param, apply it on load
     const urlParams = new URLSearchParams(window.location.search);
@@ -133,6 +140,7 @@ function filterContent(type) {
         url.searchParams.set('type', type); // keep 'movies'/'series'
     }
     window.history.pushState({}, '', url);
+    applyProcessedItemMarkers(activeProcessedItemDetails);
     applyFailedItemMarkers(activeFailedItemIds);
 }
 
@@ -384,6 +392,7 @@ async function uploadAllSelected() {
 
         showBatchResults(data.results);
         loadFailedItems({ autoExpand: true });
+        loadProcessedItems();
 
         // Refresh after short delay to update any thumbnails
         setTimeout(() => {
@@ -514,9 +523,11 @@ function renderBatchResults(results, filter) {
 function updateUploadAllButton() {
     const uploadBtn = document.getElementById('uploadAllBtn');
     const selectedCountSpan = document.getElementById('selectedCount');
+    const toolbarCount = document.getElementById('manualSelectionToolbarCount');
     const selectedCount = Object.keys(selectedPosters).length;
 
     if (selectedCountSpan) selectedCountSpan.textContent = selectedCount;
+    if (toolbarCount) toolbarCount.textContent = selectedCount;
 
     if (uploadBtn) {
         if (selectedCount > 0) {
@@ -527,6 +538,26 @@ function updateUploadAllButton() {
             uploadBtn.innerHTML = '<i class="fas fa-cloud-upload-alt me-2"></i>Upload All Selected';
         }
     }
+
+    updateManualSelectionVisibility();
+}
+
+function updateManualSelectionVisibility() {
+    const manualRow = document.getElementById('manualSelectionRow');
+    const toolbarBtn = document.getElementById('manualSelectionToolbarBtn');
+    const selectedCount = Object.keys(selectedPosters).length;
+    const shouldShow = selectedCount > 0 || manualSelectionVisible;
+
+    if (manualRow) manualRow.style.display = shouldShow ? '' : 'none';
+    if (toolbarBtn) {
+        toolbarBtn.classList.toggle('active', shouldShow);
+        toolbarBtn.setAttribute('aria-expanded', shouldShow ? 'true' : 'false');
+    }
+}
+
+function toggleManualSelectionPanel() {
+    manualSelectionVisible = !manualSelectionVisible;
+    updateManualSelectionVisibility();
 }
 
 // Notifications
@@ -571,6 +602,13 @@ function formatOperationLabel(operation) {
         .replace(/\b\w/g, letter => letter.toUpperCase());
 }
 
+function formatLogTimestamp(timestamp) {
+    if (!timestamp) return 'Unknown time';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return timestamp;
+    return date.toLocaleString();
+}
+
 async function loadFailedItems(options = {}) {
     const failedItemsBody = document.getElementById('failedItemsBody');
     const failedItemsCount = document.getElementById('failedItemsCount');
@@ -587,8 +625,12 @@ async function loadFailedItems(options = {}) {
 
         const items = data.items || [];
         activeFailedItemIds = new Set(items.map(item => item.item_id).filter(Boolean));
+        activeFailedItemDetails = new Map(items.filter(item => item.item_id).map(item => [item.item_id, item]));
+        applyProcessedItemMarkers(activeProcessedItemDetails);
         applyFailedItemMarkers(activeFailedItemIds);
         failedItemsCount.textContent = items.length;
+        const toolbarCount = document.getElementById('failedItemsToolbarCount');
+        if (toolbarCount) toolbarCount.textContent = items.length;
         retryAllBtn.disabled = items.length === 0;
         clearBtn.disabled = items.length === 0;
         failedItemsRow.style.display = items.length === 0 ? 'none' : '';
@@ -646,24 +688,71 @@ async function loadFailedItems(options = {}) {
 
 function updateFailedItemsPanelVisibility() {
     const failedItemsPanel = document.getElementById('failedItemsPanel');
-    const toggleBtn = document.getElementById('toggleFailedItemsBtn');
     const failedItemsCount = document.getElementById('failedItemsCount');
     const failedItemsRow = document.getElementById('failedItemsRow');
-    if (!failedItemsPanel || !toggleBtn || !failedItemsCount || !failedItemsRow) return;
+    const toolbarBtn = document.getElementById('failedItemsToolbarBtn');
+    if (!failedItemsPanel || !failedItemsCount || !failedItemsRow) return;
 
     const hasItems = Number(failedItemsCount.textContent) > 0;
-    failedItemsRow.style.display = hasItems ? '' : 'none';
-    toggleBtn.disabled = !hasItems;
+    failedItemsRow.style.display = hasItems && failedItemsPanelVisible ? '' : 'none';
     failedItemsPanel.style.display = hasItems && failedItemsPanelVisible ? 'block' : 'none';
-    toggleBtn.setAttribute('aria-expanded', hasItems && failedItemsPanelVisible ? 'true' : 'false');
-    toggleBtn.innerHTML = hasItems && failedItemsPanelVisible ?
-        '<i class="fas fa-eye-slash me-1"></i>Hide' :
-        '<i class="fas fa-eye me-1"></i>Show';
+    if (toolbarBtn) {
+        toolbarBtn.disabled = !hasItems;
+        toolbarBtn.classList.toggle('active', hasItems && failedItemsPanelVisible);
+        toolbarBtn.setAttribute('aria-expanded', hasItems && failedItemsPanelVisible ? 'true' : 'false');
+    }
 }
 
-function toggleFailedItemsPanel() {
+async function toggleFailedItemsFromToolbar() {
+    if (!failedItemsPanelVisible) {
+        await loadFailedItems();
+    }
+    const failedItemsCount = document.getElementById('failedItemsCount');
+    if (!failedItemsCount || Number(failedItemsCount.textContent) === 0) return;
     failedItemsPanelVisible = !failedItemsPanelVisible;
     updateFailedItemsPanelVisibility();
+}
+
+async function loadProcessedItems() {
+    try {
+        const response = await fetch('/processed-items?limit=1000');
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Failed to load processed items');
+
+        const items = data.items || [];
+        activeProcessedItemDetails = new Map(items.filter(item => item.item_id).map(item => [item.item_id, item]));
+        applyProcessedItemMarkers(activeProcessedItemDetails);
+        applyFailedItemMarkers(activeFailedItemIds);
+    } catch (error) {
+        console.error('Processed items error:', error);
+    }
+}
+
+function applyProcessedItemMarkers(itemDetails) {
+    document.querySelectorAll('.item-card-wrapper').forEach(wrapper => {
+        const itemId = wrapper.getAttribute('data-item-id');
+        const card = wrapper.querySelector('.item-card');
+        const posterWrapper = wrapper.querySelector('.card-img-top-wrapper');
+        if (!card || !posterWrapper) return;
+
+        const detail = itemDetails.get(itemId);
+        const isProcessed = Boolean(detail) && !activeFailedItemIds.has(itemId);
+        card.classList.toggle('processed-item', isProcessed);
+
+        let overlay = wrapper.querySelector('.processed-item-overlay');
+        if (isProcessed && !overlay) {
+            overlay = document.createElement('div');
+            overlay.className = 'processed-item-overlay';
+            posterWrapper.insertBefore(overlay, posterWrapper.firstChild);
+        }
+
+        if (isProcessed && overlay) {
+            overlay.title = `Processed ${formatLogTimestamp(detail.timestamp)}`;
+            overlay.innerHTML = '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Processed</span>';
+        } else if (!isProcessed && overlay) {
+            overlay.remove();
+        }
+    });
 }
 
 function applyFailedItemMarkers(itemIds) {
@@ -674,14 +763,27 @@ function applyFailedItemMarkers(itemIds) {
         if (!card || !posterWrapper) return;
 
         const isFailed = itemIds.has(itemId);
+        const detail = activeFailedItemDetails.get(itemId);
         card.classList.toggle('failed-item', isFailed);
+
+        const processedOverlay = wrapper.querySelector('.processed-item-overlay');
+        if (isFailed && processedOverlay) {
+            processedOverlay.remove();
+            card.classList.remove('processed-item');
+        }
 
         let overlay = wrapper.querySelector('.failed-item-overlay');
         if (isFailed && !overlay) {
             overlay = document.createElement('div');
             overlay.className = 'failed-item-overlay';
-            overlay.innerHTML = '<span class="badge bg-danger"><i class="fas fa-triangle-exclamation me-1"></i>Failed</span>';
             posterWrapper.insertBefore(overlay, posterWrapper.firstChild);
+        }
+
+        if (isFailed && overlay) {
+            const reason = detail?.error || 'Unknown failure';
+            const timestamp = formatLogTimestamp(detail?.timestamp);
+            overlay.title = `Failed ${timestamp}\n${reason}`;
+            overlay.innerHTML = '<span class="badge bg-danger"><i class="fas fa-triangle-exclamation me-1"></i>Failed</span>';
         } else if (!isFailed && overlay) {
             overlay.remove();
         }
@@ -732,10 +834,14 @@ async function clearFailedItems() {
         const failedItemsCount = document.getElementById('failedItemsCount');
         const failedItemsPanel = document.getElementById('failedItemsPanel');
         const failedItemsRow = document.getElementById('failedItemsRow');
+        const failedToolbarCount = document.getElementById('failedItemsToolbarCount');
         if (failedItemsBody) failedItemsBody.innerHTML = '';
         if (failedItemsCount) failedItemsCount.textContent = '0';
+        if (failedToolbarCount) failedToolbarCount.textContent = '0';
         activeFailedItemIds = new Set();
+        activeFailedItemDetails = new Map();
         applyFailedItemMarkers(activeFailedItemIds);
+        applyProcessedItemMarkers(activeProcessedItemDetails);
         failedItemsPanelVisible = false;
         if (failedItemsRow) failedItemsRow.style.display = 'none';
         if (failedItemsPanel) updateFailedItemsPanelVisibility();
@@ -771,6 +877,7 @@ async function retryFailedItem(itemId, button) {
 
         showAlert(`Poster retry succeeded for ${data.item_title || itemId}`, 'success');
         loadFailedItems();
+        loadProcessedItems();
     } catch (error) {
         console.error('Retry failed item error:', error);
         showAlert('Retry failed: ' + error.message, 'danger');
@@ -801,6 +908,7 @@ async function retryAllFailedItems() {
 
         showBatchResults(data.results || []);
         loadFailedItems({ autoExpand: true });
+        loadProcessedItems();
     } catch (error) {
         console.error('Retry all failed items error:', error);
         showAlert('Retry all failed: ' + error.message, 'danger');
@@ -808,6 +916,160 @@ async function retryAllFailedItems() {
         if (retryAllBtn) {
             retryAllBtn.disabled = false;
             retryAllBtn.innerHTML = '<i class="fas fa-rotate-right me-1"></i>Retry All';
+        }
+    }
+}
+
+function formatPhaseLabel(phase) {
+    const labels = {
+        starting: 'Starting',
+        preparing: 'Preparing',
+        loading: 'Loading',
+        searching: 'Searching',
+        downloading: 'Downloading',
+        applying: 'Applying',
+        applied: 'Applied',
+        failed: 'Failed',
+        rate_limited: 'Rate Limited',
+        completed: 'Completed'
+    };
+    return labels[phase] || formatOperationLabel(phase || 'starting');
+}
+
+function setAutoBatchRunning(isRunning) {
+    const autoBtn = document.getElementById('autoPosterBtn');
+    const cancelBtn = document.getElementById('cancelAutoBatchBtn');
+
+    if (autoBtn) {
+        autoBtn.disabled = isRunning;
+        autoBtn.innerHTML = isRunning ?
+            '<i class="fas fa-spinner fa-spin me-1"></i> Running...' :
+            '<i class="fas fa-magic me-1"></i> Auto-Get Posters';
+    }
+    if (cancelBtn) {
+        cancelBtn.style.display = isRunning ? 'inline-block' : 'none';
+        cancelBtn.disabled = !isRunning;
+        cancelBtn.innerHTML = '<i class="fas fa-stop me-1"></i>Cancel';
+    }
+}
+
+function formatDuration(seconds) {
+    if (!Number.isFinite(seconds) || seconds < 0) return 'Calculating...';
+    const rounded = Math.round(seconds);
+    const minutes = Math.floor(rounded / 60);
+    const remainingSeconds = rounded % 60;
+    if (minutes <= 0) return `${remainingSeconds}s`;
+    return `${minutes}m ${remainingSeconds}s`;
+}
+
+function updateAutoBatchCurrentPoster(url) {
+    const img = document.getElementById('autoBatchCurrentPoster');
+    const empty = document.getElementById('autoBatchCurrentPosterEmpty');
+    if (!img || !empty) return;
+
+    if (!url) {
+        img.removeAttribute('src');
+        img.style.display = 'none';
+        empty.style.display = 'inline-block';
+        return;
+    }
+
+    img.src = '/jellyfin-image?url=' + encodeURIComponent(url);
+    img.style.display = 'block';
+    empty.style.display = 'none';
+}
+
+function calculateAutoBatchEta(job, processed, remaining) {
+    if (!autoBatchStartedAt || processed <= 0 || remaining <= 0 || job.done) {
+        return job.done ? 'Done' : 'Calculating...';
+    }
+    const elapsedSeconds = (Date.now() - autoBatchStartedAt) / 1000;
+    return formatDuration((elapsedSeconds / processed) * remaining);
+}
+
+function updateAutoBatchProgress(job) {
+    const panel = document.getElementById('autoBatchProgressPanel');
+    if (!panel || !job) return;
+
+    const total = Number(job.total_items || 0);
+    const processed = Number(job.processed || 0);
+    const remaining = Number(job.remaining ?? Math.max(total - processed, 0));
+    const percent = total > 0 ? Math.round((processed / total) * 100) : 0;
+
+    panel.style.display = 'block';
+    document.getElementById('autoBatchProgressStatus').textContent = job.message || 'Running automatic poster batch...';
+    document.getElementById('autoBatchCurrentItem').textContent = job.current_item ? `Current item: ${job.current_item}` : 'No item currently processing';
+    document.getElementById('autoBatchProgressCounts').textContent = `${processed} / ${total}`;
+    document.getElementById('autoBatchProgressBar').style.width = `${percent}%`;
+    document.getElementById('autoBatchProgressBar').setAttribute('aria-valuenow', String(percent));
+    document.getElementById('autoBatchRemaining').textContent = remaining;
+    document.getElementById('autoBatchSuccessful').textContent = job.successful || 0;
+    document.getElementById('autoBatchFailed').textContent = job.failed || 0;
+    document.getElementById('autoBatchPhase').textContent = formatPhaseLabel(job.phase);
+    document.getElementById('autoBatchEta').textContent = calculateAutoBatchEta(job, processed, remaining);
+    updateAutoBatchCurrentPoster(job.old_poster_url);
+}
+
+function stopAutoBatchPolling() {
+    if (autoBatchPollTimer) {
+        clearInterval(autoBatchPollTimer);
+        autoBatchPollTimer = null;
+    }
+}
+
+async function pollAutoBatchProgress(jobId) {
+    try {
+        const response = await fetch(`/batch-auto-poster/progress/${jobId}`);
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Failed to load batch progress');
+
+        const job = data.job;
+        updateAutoBatchProgress(job);
+
+        if (job.done) {
+            stopAutoBatchPolling();
+            setAutoBatchRunning(false);
+            currentAutoBatchJobId = null;
+            loadFailedItems({ autoExpand: true });
+            loadProcessedItems();
+
+            if (job.results && job.results.length > 0) {
+                showBatchResults(job.results);
+            }
+            if (!job.success && job.error) {
+                showAlert(job.error, 'danger');
+            }
+        }
+    } catch (error) {
+        stopAutoBatchPolling();
+        setAutoBatchRunning(false);
+        currentAutoBatchJobId = null;
+        console.error('Auto-batch progress error:', error);
+        showAlert('Failed to update auto-batch progress: ' + error.message, 'danger');
+    }
+}
+
+async function cancelAutoBatch() {
+    if (!currentAutoBatchJobId) return;
+    if (!confirm('Cancel the running Auto-Get Posters job?')) return;
+
+    const cancelBtn = document.getElementById('cancelAutoBatchBtn');
+    if (cancelBtn) {
+        cancelBtn.disabled = true;
+        cancelBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Cancelling';
+    }
+
+    try {
+        const response = await fetch(`/batch-auto-poster/cancel/${currentAutoBatchJobId}`, { method: 'POST' });
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Failed to cancel batch');
+        updateAutoBatchProgress(data.job);
+    } catch (error) {
+        console.error('Auto-batch cancel error:', error);
+        showAlert('Failed to cancel auto-batch: ' + error.message, 'danger');
+        if (cancelBtn) {
+            cancelBtn.disabled = false;
+            cancelBtn.innerHTML = '<i class="fas fa-stop me-1"></i>Cancel';
         }
     }
 }
@@ -823,45 +1085,49 @@ async function startAutoBatchPoster(filter) {
             'movies': 'Automatically find and upload posters for all Movies?',
             'series': 'Automatically find and upload posters for all Series?'
         }[filter] || 'Start automatic poster upload?';
+        const skipProcessed = Boolean(document.getElementById('skipProcessedAutoBatch')?.checked);
+        const fullConfirmText = skipProcessed ?
+            `${confirmText}\n\nAlready processed items in results.log will be skipped.` :
+            confirmText;
 
-        if (!confirm(confirmText)) return;
+        if (!confirm(fullConfirmText)) return;
 
-        const autoBtn = document.getElementById('autoPosterBtn');
-        if (autoBtn) {
-            autoBtn.disabled = true;
-            autoBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Running...';
-        }
+        stopAutoBatchPolling();
+        setAutoBatchRunning(true);
+        currentAutoBatchJobId = null;
+        autoBatchStartedAt = Date.now();
 
-        const lt = document.getElementById('loadingText');
-        if (lt) lt.textContent = 'Running automatic poster batch...';
-        if (loadingModal) loadingModal.show();
+        updateAutoBatchProgress({
+            total_items: 0,
+            processed: 0,
+            remaining: 0,
+            successful: 0,
+            failed: 0,
+            phase: 'starting',
+            message: 'Starting automatic poster batch...',
+            current_item: null,
+            old_poster_url: null,
+            new_poster_url: null
+        });
 
-        const resp = await fetch('/batch-auto-poster', {
+        const resp = await fetch('/batch-auto-poster/start', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ filter })
+            body: JSON.stringify({ filter, skip_processed: skipProcessed })
         });
 
         const data = await resp.json();
-        if (loadingModal) loadingModal.hide();
+        if (!resp.ok || !data.success) throw new Error(data.error || 'Automatic batch failed');
 
-        if (!data.success) {
-            showAlert(data.error || 'Automatic batch failed', 'danger');
-            return;
-        }
-
-        showBatchResults(data.results);
-        loadFailedItems({ autoExpand: true });
+        currentAutoBatchJobId = data.job_id;
+        await pollAutoBatchProgress(data.job_id);
+        autoBatchPollTimer = setInterval(() => pollAutoBatchProgress(data.job_id), 1000);
 
     } catch (err) {
         console.error('Auto-batch error:', err);
-        if (loadingModal) loadingModal.hide();
+        stopAutoBatchPolling();
+        setAutoBatchRunning(false);
+        currentAutoBatchJobId = null;
         showAlert('Automatic batch failed: ' + err.message, 'danger');
-    } finally {
-        const autoBtn = document.getElementById('autoPosterBtn');
-        if (autoBtn) {
-            autoBtn.disabled = false;
-            autoBtn.innerHTML = '<i class="fas fa-magic me-1"></i> Auto-Get Posters';
-        }
     }
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -85,6 +85,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initialize counters/buttons
     updateUploadAllButton();
+    loadFailedItems();
 
     // If URL has filter param, apply it on load
     const urlParams = new URLSearchParams(window.location.search);
@@ -483,10 +484,11 @@ function updateUploadAllButton() {
 
 // Notifications
 function showAlert(message, type = 'info') {
+    const safeMessage = escapeHtml(message);
     const alertHtml = `
         <div class="alert alert-${type} alert-dismissible fade show" role="alert">
             <i class="fas fa-info-circle me-2"></i>
-            ${message}
+            ${safeMessage}
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     `;
@@ -496,6 +498,127 @@ function showAlert(message, type = 'info') {
         const alert = container.querySelector('.alert');
         if (alert) alert.remove();
     }, 5000);
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+async function loadFailedItems() {
+    const failedItemsBody = document.getElementById('failedItemsBody');
+    const failedItemsCount = document.getElementById('failedItemsCount');
+    const failedItemsPanel = document.getElementById('failedItemsPanel');
+    const retryAllBtn = document.getElementById('retryAllFailedBtn');
+    if (!failedItemsBody || !failedItemsCount || !failedItemsPanel || !retryAllBtn) return;
+
+    try {
+        const response = await fetch('/failed-items?limit=100');
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Failed to load failed items');
+
+        const items = data.items || [];
+        failedItemsCount.textContent = items.length;
+        retryAllBtn.disabled = items.length === 0;
+
+        if (items.length === 0) {
+            failedItemsPanel.style.display = 'none';
+            failedItemsBody.innerHTML = '';
+            return;
+        }
+
+        failedItemsPanel.style.display = 'block';
+        failedItemsBody.innerHTML = items.map(item => {
+            const label = item.item_year ? `${item.item_title || 'Unknown'} (${item.item_year})` : (item.item_title || 'Unknown');
+            const canRetry = Boolean(item.item_id);
+            return `
+                <tr>
+                    <td>${escapeHtml(label)}</td>
+                    <td>${escapeHtml(item.item_type || '-')}</td>
+                    <td>${escapeHtml(item.operation || 'poster')}</td>
+                    <td>${escapeHtml(item.error || '-')}</td>
+                    <td class="text-end">
+                        <button class="btn btn-outline-warning btn-sm retry-failed-item-btn"
+                                type="button"
+                                data-item-id="${escapeHtml(item.item_id || '')}"
+                                ${canRetry ? '' : 'disabled'}>
+                            <i class="fas fa-rotate-right me-1"></i>Retry
+                        </button>
+                    </td>
+                </tr>
+            `;
+        }).join('');
+
+        document.querySelectorAll('.retry-failed-item-btn').forEach(button => {
+            button.addEventListener('click', () => retryFailedItem(button.getAttribute('data-item-id'), button));
+        });
+    } catch (error) {
+        console.error('Failed items error:', error);
+        showAlert('Failed to load failed items: ' + error.message, 'danger');
+    }
+}
+
+async function retryFailedItem(itemId, button) {
+    if (!itemId) return;
+    if (button) {
+        button.disabled = true;
+        button.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Retrying';
+    }
+
+    try {
+        const response = await fetch('/failed-items/retry', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ item_id: itemId })
+        });
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Retry failed');
+
+        showAlert(`Poster retry succeeded for ${data.item_title || itemId}`, 'success');
+        loadFailedItems();
+    } catch (error) {
+        console.error('Retry failed item error:', error);
+        showAlert('Retry failed: ' + error.message, 'danger');
+        if (button) {
+            button.disabled = false;
+            button.innerHTML = '<i class="fas fa-rotate-right me-1"></i>Retry';
+        }
+    }
+}
+
+async function retryAllFailedItems() {
+    const retryAllBtn = document.getElementById('retryAllFailedBtn');
+    if (!confirm('Retry poster fetch and upload for all recent failed items?')) return;
+
+    if (retryAllBtn) {
+        retryAllBtn.disabled = true;
+        retryAllBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Retrying...';
+    }
+
+    try {
+        const response = await fetch('/failed-items/retry-all', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ limit: 100 })
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Retry all failed');
+
+        showBatchResults(data.results || []);
+        loadFailedItems();
+    } catch (error) {
+        console.error('Retry all failed items error:', error);
+        showAlert('Retry all failed: ' + error.message, 'danger');
+    } finally {
+        if (retryAllBtn) {
+            retryAllBtn.disabled = false;
+            retryAllBtn.innerHTML = '<i class="fas fa-rotate-right me-1"></i>Retry All';
+        }
+    }
 }
 
 // Start automatic batch poster job

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -68,6 +68,8 @@ let selectedPosters = {};
 let loadingModal = null;
 let posterModal = null;
 let resultsModal = null;
+let failedItemsPanelVisible = false;
+let activeFailedItemIds = new Set();
 
 document.addEventListener('DOMContentLoaded', function() {
     // Theme first
@@ -81,7 +83,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const rm = document.getElementById('resultsModal');
     if (lm && bootstrap?.Modal) loadingModal = new bootstrap.Modal(lm);
     if (pm && bootstrap?.Modal) posterModal = new bootstrap.Modal(pm);
-    if (rm && bootstrap?.Modal) resultsModal = new bootstrap.Modal(rm);
+    if (rm && bootstrap?.Modal) {
+        resultsModal = new bootstrap.Modal(rm);
+        rm.addEventListener('hidden.bs.modal', () => loadFailedItems({ autoExpand: true }));
+    }
 
     // Initialize counters/buttons
     updateUploadAllButton();
@@ -128,6 +133,7 @@ function filterContent(type) {
         url.searchParams.set('type', type); // keep 'movies'/'series'
     }
     window.history.pushState({}, '', url);
+    applyFailedItemMarkers(activeFailedItemIds);
 }
 
 function sortContent(sortBy) {
@@ -377,6 +383,7 @@ async function uploadAllSelected() {
         if (progressText) progressText.textContent = '100%';
 
         showBatchResults(data.results);
+        loadFailedItems({ autoExpand: true });
 
         // Refresh after short delay to update any thumbnails
         setTimeout(() => {
@@ -403,8 +410,9 @@ function showBatchResults(results) {
 
     let successCount = results.filter(r => r.success).length;
     let failCount = results.length - successCount;
+    const defaultFilter = failCount > 0 ? 'failed' : 'all';
 
-    let html = `
+    const html = `
         <div class="row mb-3">
             <div class="col-md-6">
                 <div class="card border-success">
@@ -425,7 +433,20 @@ function showBatchResults(results) {
                 </div>
             </div>
         </div>
-        <h6>Detailed Results:</h6>
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+            <h6 class="mb-0">Detailed Results</h6>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Filter upload results">
+                <button class="btn btn-outline-secondary batch-results-filter" type="button" data-filter="all">
+                    All (${results.length})
+                </button>
+                <button class="btn btn-outline-danger batch-results-filter" type="button" data-filter="failed">
+                    Failed (${failCount})
+                </button>
+                <button class="btn btn-outline-success batch-results-filter" type="button" data-filter="successful">
+                    Successful (${successCount})
+                </button>
+            </div>
+        </div>
         <div class="table-responsive">
             <table class="table table-sm results-table">
                 <thead>
@@ -435,32 +456,58 @@ function showBatchResults(results) {
                         <th>Error</th>
                     </tr>
                 </thead>
-                <tbody>
-    `;
-
-    results.forEach(result => {
-        html += `
-            <tr>
-                <td>${result.item_title || result.item_id}</td>
-                <td>
-                    ${result.success ?
-                        '<span class="badge bg-success">Success</span>' :
-                        '<span class="badge bg-danger">Failed</span>'
-                    }
-                </td>
-                <td>${result.error || '-'}</td>
-            </tr>
-        `;
-    });
-
-    html += `
-                </tbody>
+                <tbody id="batchResultsBody"></tbody>
             </table>
         </div>
     `;
 
     modalBody.innerHTML = html;
+    renderBatchResults(results, defaultFilter);
+
+    document.querySelectorAll('.batch-results-filter').forEach(button => {
+        button.addEventListener('click', () => renderBatchResults(results, button.getAttribute('data-filter')));
+    });
+
     if (resultsModal) resultsModal.show();
+}
+
+function renderBatchResults(results, filter) {
+    const tbody = document.getElementById('batchResultsBody');
+    if (!tbody) return;
+
+    document.querySelectorAll('.batch-results-filter').forEach(button => {
+        const isActive = button.getAttribute('data-filter') === filter;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+
+    const filteredResults = results.filter(result => {
+        if (filter === 'failed') return !result.success;
+        if (filter === 'successful') return result.success;
+        return true;
+    });
+
+    if (filteredResults.length === 0) {
+        tbody.innerHTML = `
+            <tr>
+                <td class="text-muted text-center" colspan="3">No results in this filter.</td>
+            </tr>
+        `;
+        return;
+    }
+
+    tbody.innerHTML = filteredResults.map(result => `
+        <tr>
+            <td>${escapeHtml(result.item_title || result.item_id || 'Unknown')}</td>
+            <td>
+                ${result.success ?
+                    '<span class="badge bg-success">Success</span>' :
+                    '<span class="badge bg-danger">Failed</span>'
+                }
+            </td>
+            <td>${escapeHtml(result.error || '-')}</td>
+        </tr>
+    `).join('');
 }
 
 // Button enable state
@@ -509,12 +556,29 @@ function escapeHtml(value) {
         .replace(/'/g, '&#39;');
 }
 
-async function loadFailedItems() {
+function formatOperationLabel(operation) {
+    const labels = {
+        'auto-poster': 'Auto-Get Posters',
+        'manual-upload': 'Manual Upload',
+        'batch-upload': 'Batch Upload',
+        'direct-upload': 'Direct Upload',
+        'retry-auto-poster': 'Retry',
+        'retry-all-auto-poster': 'Retry All',
+        'poster': 'Poster Lookup'
+    };
+    return labels[operation] || String(operation || 'Poster Lookup')
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+async function loadFailedItems(options = {}) {
     const failedItemsBody = document.getElementById('failedItemsBody');
     const failedItemsCount = document.getElementById('failedItemsCount');
     const failedItemsPanel = document.getElementById('failedItemsPanel');
     const retryAllBtn = document.getElementById('retryAllFailedBtn');
-    if (!failedItemsBody || !failedItemsCount || !failedItemsPanel || !retryAllBtn) return;
+    const clearBtn = document.getElementById('clearFailedItemsBtn');
+    const failedItemsRow = document.getElementById('failedItemsRow');
+    if (!failedItemsBody || !failedItemsCount || !failedItemsPanel || !retryAllBtn || !clearBtn || !failedItemsRow) return;
 
     try {
         const response = await fetch('/failed-items?limit=100');
@@ -522,24 +586,39 @@ async function loadFailedItems() {
         if (!response.ok) throw new Error(data.error || 'Failed to load failed items');
 
         const items = data.items || [];
+        activeFailedItemIds = new Set(items.map(item => item.item_id).filter(Boolean));
+        applyFailedItemMarkers(activeFailedItemIds);
         failedItemsCount.textContent = items.length;
         retryAllBtn.disabled = items.length === 0;
+        clearBtn.disabled = items.length === 0;
+        failedItemsRow.style.display = items.length === 0 ? 'none' : '';
+        if (options.autoExpand && items.length > 0) {
+            failedItemsPanelVisible = true;
+        }
 
         if (items.length === 0) {
-            failedItemsPanel.style.display = 'none';
+            failedItemsPanelVisible = false;
+            updateFailedItemsPanelVisibility();
             failedItemsBody.innerHTML = '';
             return;
         }
 
-        failedItemsPanel.style.display = 'block';
+        updateFailedItemsPanelVisibility();
         failedItemsBody.innerHTML = items.map(item => {
             const label = item.item_year ? `${item.item_title || 'Unknown'} (${item.item_year})` : (item.item_title || 'Unknown');
             const canRetry = Boolean(item.item_id);
+            const itemLabel = canRetry ? `
+                <button class="btn btn-link btn-sm p-0 failed-item-link"
+                        type="button"
+                        data-item-id="${escapeHtml(item.item_id)}">
+                    ${escapeHtml(label)}
+                </button>
+            ` : escapeHtml(label);
             return `
                 <tr>
-                    <td>${escapeHtml(label)}</td>
+                    <td>${itemLabel}</td>
                     <td>${escapeHtml(item.item_type || '-')}</td>
-                    <td>${escapeHtml(item.operation || 'poster')}</td>
+                    <td>${escapeHtml(formatOperationLabel(item.operation))}</td>
                     <td>${escapeHtml(item.error || '-')}</td>
                     <td class="text-end">
                         <button class="btn btn-outline-warning btn-sm retry-failed-item-btn"
@@ -556,9 +635,121 @@ async function loadFailedItems() {
         document.querySelectorAll('.retry-failed-item-btn').forEach(button => {
             button.addEventListener('click', () => retryFailedItem(button.getAttribute('data-item-id'), button));
         });
+        document.querySelectorAll('.failed-item-link').forEach(button => {
+            button.addEventListener('click', () => scrollToItemCard(button.getAttribute('data-item-id')));
+        });
     } catch (error) {
         console.error('Failed items error:', error);
         showAlert('Failed to load failed items: ' + error.message, 'danger');
+    }
+}
+
+function updateFailedItemsPanelVisibility() {
+    const failedItemsPanel = document.getElementById('failedItemsPanel');
+    const toggleBtn = document.getElementById('toggleFailedItemsBtn');
+    const failedItemsCount = document.getElementById('failedItemsCount');
+    const failedItemsRow = document.getElementById('failedItemsRow');
+    if (!failedItemsPanel || !toggleBtn || !failedItemsCount || !failedItemsRow) return;
+
+    const hasItems = Number(failedItemsCount.textContent) > 0;
+    failedItemsRow.style.display = hasItems ? '' : 'none';
+    toggleBtn.disabled = !hasItems;
+    failedItemsPanel.style.display = hasItems && failedItemsPanelVisible ? 'block' : 'none';
+    toggleBtn.setAttribute('aria-expanded', hasItems && failedItemsPanelVisible ? 'true' : 'false');
+    toggleBtn.innerHTML = hasItems && failedItemsPanelVisible ?
+        '<i class="fas fa-eye-slash me-1"></i>Hide' :
+        '<i class="fas fa-eye me-1"></i>Show';
+}
+
+function toggleFailedItemsPanel() {
+    failedItemsPanelVisible = !failedItemsPanelVisible;
+    updateFailedItemsPanelVisibility();
+}
+
+function applyFailedItemMarkers(itemIds) {
+    document.querySelectorAll('.item-card-wrapper').forEach(wrapper => {
+        const itemId = wrapper.getAttribute('data-item-id');
+        const card = wrapper.querySelector('.item-card');
+        const posterWrapper = wrapper.querySelector('.card-img-top-wrapper');
+        if (!card || !posterWrapper) return;
+
+        const isFailed = itemIds.has(itemId);
+        card.classList.toggle('failed-item', isFailed);
+
+        let overlay = wrapper.querySelector('.failed-item-overlay');
+        if (isFailed && !overlay) {
+            overlay = document.createElement('div');
+            overlay.className = 'failed-item-overlay';
+            overlay.innerHTML = '<span class="badge bg-danger"><i class="fas fa-triangle-exclamation me-1"></i>Failed</span>';
+            posterWrapper.insertBefore(overlay, posterWrapper.firstChild);
+        } else if (!isFailed && overlay) {
+            overlay.remove();
+        }
+    });
+}
+
+function scrollToItemCard(itemId) {
+    if (!itemId) return;
+
+    const wrapper = Array.from(document.querySelectorAll('.item-card-wrapper'))
+        .find(item => item.getAttribute('data-item-id') === itemId);
+    if (!wrapper) {
+        showAlert('That item is not currently visible in the library grid.', 'warning');
+        return;
+    }
+
+    if (wrapper.classList.contains('hidden')) {
+        wrapper.classList.remove('hidden');
+        showAlert('Showing the failed item even though it is outside the current filter.', 'info');
+    }
+
+    wrapper.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    const card = wrapper.querySelector('.item-card');
+    if (card) {
+        card.classList.remove('failed-card-focus');
+        void card.offsetWidth;
+        card.classList.add('failed-card-focus');
+    }
+}
+
+async function clearFailedItems() {
+    if (!confirm('Clear all failed item entries from failed.log?')) return;
+
+    const clearBtn = document.getElementById('clearFailedItemsBtn');
+    const retryAllBtn = document.getElementById('retryAllFailedBtn');
+    if (clearBtn) {
+        clearBtn.disabled = true;
+        clearBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Clearing';
+    }
+
+    try {
+        const response = await fetch('/failed-items', { method: 'DELETE' });
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Failed to clear failed items');
+
+        const failedItemsBody = document.getElementById('failedItemsBody');
+        const failedItemsCount = document.getElementById('failedItemsCount');
+        const failedItemsPanel = document.getElementById('failedItemsPanel');
+        const failedItemsRow = document.getElementById('failedItemsRow');
+        if (failedItemsBody) failedItemsBody.innerHTML = '';
+        if (failedItemsCount) failedItemsCount.textContent = '0';
+        activeFailedItemIds = new Set();
+        applyFailedItemMarkers(activeFailedItemIds);
+        failedItemsPanelVisible = false;
+        if (failedItemsRow) failedItemsRow.style.display = 'none';
+        if (failedItemsPanel) updateFailedItemsPanelVisibility();
+        if (retryAllBtn) retryAllBtn.disabled = true;
+        showAlert('Failed items cleared', 'success');
+    } catch (error) {
+        console.error('Clear failed items error:', error);
+        showAlert('Failed to clear failed items: ' + error.message, 'danger');
+    } finally {
+        if (clearBtn) {
+            clearBtn.disabled = false;
+            clearBtn.innerHTML = '<i class="fas fa-trash me-1"></i>Clear';
+        }
+        loadFailedItems();
     }
 }
 
@@ -609,7 +800,7 @@ async function retryAllFailedItems() {
         if (!response.ok) throw new Error(data.error || 'Retry all failed');
 
         showBatchResults(data.results || []);
-        loadFailedItems();
+        loadFailedItems({ autoExpand: true });
     } catch (error) {
         console.error('Retry all failed items error:', error);
         showAlert('Retry all failed: ' + error.message, 'danger');
@@ -660,6 +851,7 @@ async function startAutoBatchPoster(filter) {
         }
 
         showBatchResults(data.results);
+        loadFailedItems({ autoExpand: true });
 
     } catch (err) {
         console.error('Auto-batch error:', err);

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,38 +45,8 @@
     </div>
 </div>
 
-<!-- Sort Dropdown Row -->
-<div class="row mb-4">
-    <div class="col-12 d-flex justify-content-end">
-        <div class="dropdown">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button"
-                    id="sortDropdownBtn" data-bs-toggle="dropdown" aria-expanded="false" data-bs-boundary="viewport">
-                <i class="fas fa-sort me-1"></i>
-                Sort by
-            </button>
-            <ul class="dropdown-menu" aria-labelledby="sortDropdownBtn">
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'name' else '' }}" href="#" onclick="sortContent('name')">
-                        <i class="fas fa-sort-alpha-down me-2"></i>Name (A-Z)
-                    </a>
-                </li>
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'year' else '' }}" href="#" onclick="sortContent('year')">
-                        <i class="fas fa-calendar me-2"></i>Year
-                    </a>
-                </li>
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'date_added' else '' }}" href="#" onclick="sortContent('date_added')">
-                        <i class="fas fa-clock me-2"></i>Recently Added
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
-
 <!-- Manual Selection -->
-<div class="row mb-3">
+<div class="row mb-3" id="manualSelectionRow" style="display: none;">
     <div class="col-12">
         <div class="card">
             <div class="card-body py-3">
@@ -125,7 +95,12 @@
                             Automatically find and upload the first available poster for items
                         </small>
                     </div>
-                    <div class="col-md-4 text-md-end">
+                    <div class="col-md-4">
+                        <div class="d-flex flex-wrap align-items-center justify-content-md-end gap-2">
+                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
+                                <input class="form-check-input me-2" type="checkbox" role="switch" id="skipProcessedAutoBatch">
+                                <label class="form-check-label small text-muted" for="skipProcessedAutoBatch">Skip already processed</label>
+                            </div>
                         <div class="dropdown">
                             <button type="button" class="btn btn-outline-primary dropdown-toggle"
                                     data-bs-toggle="dropdown" aria-expanded="false" id="autoPosterBtn" data-bs-boundary="viewport">
@@ -160,6 +135,52 @@
                                 </li>
                             </ul>
                         </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="autoBatchProgressPanel" class="auto-batch-progress mt-3" style="display: none;">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div class="d-flex align-items-center gap-2">
+                            <div class="auto-batch-current-preview">
+                                <img id="autoBatchCurrentPoster" alt="Current poster preview" style="display: none;">
+                                <i id="autoBatchCurrentPosterEmpty" class="fas fa-image text-muted"></i>
+                            </div>
+                            <div>
+                                <strong id="autoBatchProgressStatus">Starting...</strong>
+                                <small class="text-muted d-block" id="autoBatchCurrentItem">Preparing batch</small>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <small class="text-muted d-block" id="autoBatchProgressCounts">0 / 0</small>
+                            <button class="btn btn-outline-danger btn-sm mt-1" type="button" id="cancelAutoBatchBtn" onclick="cancelAutoBatch()" style="display: none;">
+                                <i class="fas fa-stop me-1"></i>Cancel
+                            </button>
+                        </div>
+                    </div>
+                    <div class="progress">
+                        <div id="autoBatchProgressBar" class="progress-bar" role="progressbar" style="width: 0%"></div>
+                    </div>
+                    <div class="row text-center mt-2 g-2">
+                        <div class="col-6 col-md-3">
+                            <small class="text-muted d-block">Remaining</small>
+                            <strong id="autoBatchRemaining">0</strong>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <small class="text-muted d-block">Successful</small>
+                            <strong class="text-success" id="autoBatchSuccessful">0</strong>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <small class="text-muted d-block">Failed</small>
+                            <strong class="text-danger" id="autoBatchFailed">0</strong>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <small class="text-muted d-block">Status</small>
+                            <strong id="autoBatchPhase">Starting</strong>
+                        </div>
+                        <div class="col-12 mt-2">
+                            <small class="text-muted d-block">Estimated time remaining</small>
+                            <strong id="autoBatchEta">Calculating...</strong>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -178,20 +199,17 @@
                             <i class="fas fa-triangle-exclamation me-2"></i>Failed Items
                             <span class="badge bg-danger ms-2" id="failedItemsCount">0</span>
                         </h5>
-                        <small class="text-muted">Recent poster fetch or upload failures from failed.log</small>
+                        <small class="text-muted">Recent poster fetch or upload failures</small>
                     </div>
                     <div class="col-md-6 text-md-end">
-                        <button class="btn btn-outline-secondary btn-sm me-2" type="button" id="toggleFailedItemsBtn" onclick="toggleFailedItemsPanel()" aria-expanded="false">
-                            <i class="fas fa-eye me-1"></i>Show
-                        </button>
-                        <button class="btn btn-outline-secondary btn-sm me-2" type="button" onclick="loadFailedItems()">
-                            <i class="fas fa-rotate me-1"></i>Refresh
-                        </button>
                         <button class="btn btn-outline-danger btn-sm me-2" type="button" id="clearFailedItemsBtn" onclick="clearFailedItems()" disabled>
-                            <i class="fas fa-trash me-1"></i>Clear
+                            <i class="fas fa-trash me-1"></i>Clear list
                         </button>
-                        <button class="btn btn-outline-warning btn-sm" type="button" id="retryAllFailedBtn" onclick="retryAllFailedItems()" disabled>
-                            <i class="fas fa-rotate-right me-1"></i>Retry All
+                        <button class="btn btn-outline-warning btn-sm me-2" type="button" id="retryAllFailedBtn" onclick="retryAllFailedItems()" disabled>
+                            <i class="fas fa-rotate-right me-1"></i>Retry all
+                        </button>
+                        <button class="btn btn-outline-secondary btn-sm" type="button" onclick="loadFailedItems()">
+                            <i class="fas fa-rotate me-1"></i>Refresh
                         </button>
                     </div>
                 </div>
@@ -211,6 +229,46 @@
                     </table>
                 </div>
             </div>
+        </div>
+    </div>
+</div>
+
+<!-- Grid Tools -->
+<div class="row mb-3">
+    <div class="col-12 d-flex flex-wrap justify-content-end gap-2">
+        <button class="btn btn-outline-secondary btn-sm" type="button" id="manualSelectionToolbarBtn" onclick="toggleManualSelectionPanel()" aria-expanded="false">
+            <i class="fas fa-tasks me-1"></i>
+            Manual
+            <span class="badge bg-secondary ms-1" id="manualSelectionToolbarCount">0</span>
+        </button>
+        <button class="btn btn-outline-secondary btn-sm" type="button" id="failedItemsToolbarBtn" onclick="toggleFailedItemsFromToolbar()" aria-expanded="false">
+            <i class="fas fa-triangle-exclamation me-1"></i>
+            Failed
+            <span class="badge bg-danger ms-1" id="failedItemsToolbarCount">0</span>
+        </button>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button"
+                    id="sortDropdownBtn" data-bs-toggle="dropdown" aria-expanded="false" data-bs-boundary="viewport">
+                <i class="fas fa-sort me-1"></i>
+                Sort by
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="sortDropdownBtn">
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'name' else '' }}" href="#" onclick="sortContent('name')">
+                        <i class="fas fa-sort-alpha-down me-2"></i>Name (A-Z)
+                    </a>
+                </li>
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'year' else '' }}" href="#" onclick="sortContent('year')">
+                        <i class="fas fa-calendar me-2"></i>Year
+                    </a>
+                </li>
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'date_added' else '' }}" href="#" onclick="sortContent('date_added')">
+                        <i class="fas fa-clock me-2"></i>Recently Added
+                    </a>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,6 +167,48 @@
     </div>
 </div>
 
+<!-- Failed Items -->
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card failed-items-card">
+            <div class="card-body py-3">
+                <div class="row align-items-center g-3">
+                    <div class="col-md-6">
+                        <h5 class="mb-0">
+                            <i class="fas fa-triangle-exclamation me-2"></i>Failed Items
+                            <span class="badge bg-danger ms-2" id="failedItemsCount">0</span>
+                        </h5>
+                        <small class="text-muted">Recent poster fetch or upload failures from failed.log</small>
+                    </div>
+                    <div class="col-md-6 text-md-end">
+                        <button class="btn btn-outline-secondary btn-sm me-2" type="button" onclick="loadFailedItems()">
+                            <i class="fas fa-rotate me-1"></i>Refresh
+                        </button>
+                        <button class="btn btn-outline-warning btn-sm" type="button" id="retryAllFailedBtn" onclick="retryAllFailedItems()" disabled>
+                            <i class="fas fa-rotate-right me-1"></i>Retry All
+                        </button>
+                    </div>
+                </div>
+
+                <div class="table-responsive mt-3" id="failedItemsPanel" style="display: none;">
+                    <table class="table table-sm align-middle results-table mb-0">
+                        <thead>
+                            <tr>
+                                <th>Item</th>
+                                <th>Type</th>
+                                <th>Operation</th>
+                                <th>Error</th>
+                                <th class="text-end">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody id="failedItemsBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Items Grid -->
 <div class="row" id="itemsGrid">
     {% for item in items %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,7 +168,7 @@
 </div>
 
 <!-- Failed Items -->
-<div class="row mb-4">
+<div class="row mb-4" id="failedItemsRow" style="display: none;">
     <div class="col-12">
         <div class="card failed-items-card">
             <div class="card-body py-3">
@@ -181,8 +181,14 @@
                         <small class="text-muted">Recent poster fetch or upload failures from failed.log</small>
                     </div>
                     <div class="col-md-6 text-md-end">
+                        <button class="btn btn-outline-secondary btn-sm me-2" type="button" id="toggleFailedItemsBtn" onclick="toggleFailedItemsPanel()" aria-expanded="false">
+                            <i class="fas fa-eye me-1"></i>Show
+                        </button>
                         <button class="btn btn-outline-secondary btn-sm me-2" type="button" onclick="loadFailedItems()">
                             <i class="fas fa-rotate me-1"></i>Refresh
+                        </button>
+                        <button class="btn btn-outline-danger btn-sm me-2" type="button" id="clearFailedItemsBtn" onclick="clearFailedItems()" disabled>
+                            <i class="fas fa-trash me-1"></i>Clear
                         </button>
                         <button class="btn btn-outline-warning btn-sm" type="button" id="retryAllFailedBtn" onclick="retryAllFailedItems()" disabled>
                             <i class="fas fa-rotate-right me-1"></i>Retry All
@@ -252,7 +258,7 @@
                 {% endif %}
 
                 <div class="d-grid">
-                    <button class="btn btn-outline-primary btn-sm" onclick="loadPosters('{{ item.id }}')">
+                    <button class="btn btn-outline-primary btn-sm find-posters-btn" onclick="loadPosters('{{ item.id }}')">
                         <i class="fas fa-search me-1"></i>
                         Find Posters
                     </button>


### PR DESCRIPTION
Fixes #18, fixes #19

Adds better visibility and recovery tools for Auto-Get Posters and poster upload workflows.

## Changes

- Add `failed.log` tracking for failed poster fetch/upload attempts.
- Add `results.log` tracking for successful poster applications.
- Add a Failed Items UI with:
  - latest active failure per item
  - retry individual item
  - retry all failed items
  - clear failed items
  - clickable item names that scroll to the matching library card
- Mark failed library cards visually with a failed badge, reason, and timestamp.
- Mark successfully processed cards with a processed badge and timestamp.
- Add live Auto-Get Posters progress with:
  - current item
  - processed/remaining counts
  - success/failure counts
  - status phase
  - ETA
  - cancel support
- Add “Skip already processed” support using `results.log`.
- Move grid controls closer to the poster list:
  - Sort by
  - Manual Selection toggle
  - Failed Items toggle
- Improve Upload Results filtering with All / Failed / Successful views.
- Polish dark-theme table borders and related UI states.

## Testing

- Ran `python -m compileall app.py`
- Ran `node --check static/js/app.js`

## Screenshots

<img width="1679" height="891" alt="image" src="https://github.com/user-attachments/assets/b4d09a32-c770-415f-916d-3baace5fc7c9" />

<img width="1671" height="604" alt="image" src="https://github.com/user-attachments/assets/ed3a8c88-fdd8-43d2-bdd3-d1850be1ada5" />

<img width="1680" height="654" alt="image" src="https://github.com/user-attachments/assets/481107fa-8460-4175-be43-59e92e99638a" />

<img width="1649" height="342" alt="image" src="https://github.com/user-attachments/assets/51576e52-8a55-4016-8f78-b13d8bf51773" />

<img width="1107" height="536" alt="image" src="https://github.com/user-attachments/assets/ca77493e-3654-4247-97d7-d7832e5c5e6a" />
