### PR TITLE
Improve TPDB poster matching and show Find Posters progress

### DIFF
--- a/app.py
+++ b/app.py
@@ -824,13 +824,6 @@ def _select_auto_batch_target_items(all_items, target_filter, skip_processed=Fal
     else:
         target_items = []
 
-    # TEMP: constrain auto-poster runs for issue #18 testing.
-    test_titles = {'cowboy bebop', 'crash landing on you', 'claymore'}
-    target_items = [
-        item for item in all_items
-        if (item.get('title') or '').strip().lower() in test_titles
-    ]
-
     if skip_processed:
         processed_item_ids = _read_processed_item_ids()
         target_items = [item for item in target_items if item.get('id') not in processed_item_ids]

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -432,53 +432,103 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
                         logging.info(f"No TPDB search results for '{search_query}'.")
                         return []
 
-                    best_match = None
-                    best_match_score = 0
-                    for link in search_result_links:
+                    expected_year = extract_title_year(search_query) or (str(item_year) if item_year else None)
+                    candidate_links = []
+                    for index, link in enumerate(search_result_links):
                         try:
                             title_element = link.find(class_="text-truncate") or link.find("span") or link
                             result_title = title_element.get_text(strip=True) if title_element else link.get_text(strip=True)
+                            result_year = extract_title_year(result_title)
+                            if expected_year and result_year and result_year != expected_year:
+                                logging.info(
+                                    "Skipping TPDB result for '%s' due to year mismatch: %s",
+                                    search_query,
+                                    result_title,
+                                )
+                                continue
                             score = calculate_title_match_score(search_query, result_title)
-                            if score > best_match_score:
-                                best_match_score = score
-                                best_match = link
+                            item_page_path = link.get('href')
+                            if not item_page_path:
+                                continue
+                            target_item_page_url = item_page_path if item_page_path.startswith('http') else (
+                                Config.TPDB_BASE_URL + item_page_path if item_page_path.startswith('/') else None
+                            )
+                            if not target_item_page_url:
+                                continue
+                            candidate_links.append({
+                                'title': result_title,
+                                'year': result_year,
+                                'score': score,
+                                'url': target_item_page_url,
+                                'index': index,
+                            })
                         except Exception:
                             continue
 
-                    selected_link = best_match if best_match and best_match_score >= 0.8 else search_result_links[0]
-
-                    item_page_path = selected_link.get('href')
-                    if not item_page_path:
+                    if not candidate_links:
                         return []
-                    target_item_page_url = item_page_path if item_page_path.startswith('http') else (
-                        Config.TPDB_BASE_URL + item_page_path if item_page_path.startswith('/') else None
+
+                    strong_matches = [candidate for candidate in candidate_links if candidate['score'] >= 0.8]
+                    candidates_to_check = strong_matches or candidate_links
+                    candidates_to_check = sorted(
+                        candidates_to_check,
+                        key=lambda candidate: (-candidate['score'], candidate['index'])
                     )
-                    if not target_item_page_url:
-                        return []
 
-                    selenium_driver.get(target_item_page_url)
-                    current_url = selenium_driver.current_url
-                    if _is_login_url(current_url):
-                        logging.warning("TPDB session expired on item page for '%s' (%s).", item_title, current_url)
-                        raise TPDBSessionExpired("TPDB session expired while loading item page.")
-
-                    _raise_if_rate_limited(selenium_driver.page_source, current_url, "item_page")
-                    _wait_for_item_posters_ready(selenium_driver, timeout=15)
-                    item_soup = BeautifulSoup(selenium_driver.page_source, 'html.parser')
-
-                    poster_links = item_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]
                     poster_urls = []
-                    for poster_link in poster_links:
-                        href = poster_link.get('href')
-                        if not href:
+                    for candidate in candidates_to_check:
+                        logging.info(
+                            "Checking TPDB result for '%s': %s (score %.2f)",
+                            search_query,
+                            candidate['title'],
+                            candidate['score'],
+                        )
+                        selenium_driver.get(candidate['url'])
+                        current_url = selenium_driver.current_url
+                        if _is_login_url(current_url):
+                            logging.warning("TPDB session expired on item page for '%s' (%s).", item_title, current_url)
+                            raise TPDBSessionExpired("TPDB session expired while loading item page.")
+
+                        _raise_if_rate_limited(selenium_driver.page_source, current_url, "item_page")
+
+                        try:
+                            _wait_for_item_posters_ready(selenium_driver, timeout=15)
+                        except TimeoutError:
+                            logging.warning(
+                                "Timed out checking TPDB result '%s' for '%s'; trying next result.",
+                                candidate['title'],
+                                search_query,
+                            )
                             continue
-                        if href.startswith('http'):
-                            poster_url = href
-                        elif href.startswith('/'):
-                            poster_url = Config.TPDB_BASE_URL + href
-                        else:
-                            continue
-                        poster_urls.append(poster_url)
+
+                        item_soup = BeautifulSoup(selenium_driver.page_source, 'html.parser')
+                        poster_links = item_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]
+                        for poster_link in poster_links:
+                            href = poster_link.get('href')
+                            if not href:
+                                continue
+                            if href.startswith('http'):
+                                poster_url = href
+                            elif href.startswith('/'):
+                                poster_url = Config.TPDB_BASE_URL + href
+                            else:
+                                continue
+                            poster_urls.append(poster_url)
+
+                        if poster_urls:
+                            logging.info(
+                                "Using TPDB result '%s' for '%s' with %d poster(s).",
+                                candidate['title'],
+                                search_query,
+                                len(poster_urls),
+                            )
+                            break
+
+                        logging.info(
+                            "TPDB result '%s' for '%s' had no posters; trying next result.",
+                            candidate['title'],
+                            search_query,
+                        )
                 break
             except TPDBSessionExpired:
                 if attempt == 0:
@@ -548,6 +598,12 @@ def calculate_title_match_score(expected_title, result_title):
 
     common = expected_words.intersection(result_words)
     return len(common) / max(len(expected_words), len(result_words))
+
+def extract_title_year(title):
+    if not title:
+        return None
+    year_match = re.search(r'\((\d{4})\)', title)
+    return year_match.group(1) if year_match else None
 
 def normalize_title_for_comparison(title):
     if not title:

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -76,6 +76,7 @@ let autoBatchPollTimer = null;
 let currentAutoBatchJobId = null;
 let autoBatchStartedAt = null;
 let manualSelectionVisible = false;
+let posterSearchProgressTimer = null;
 
 document.addEventListener('DOMContentLoaded', function() {
     // Theme first
@@ -150,11 +151,45 @@ function sortContent(sortBy) {
     window.location.href = url.toString();
 }
 
+function startPosterSearchProgress() {
+    stopPosterSearchProgress();
+
+    const loadingText = document.getElementById('loadingText');
+    const loadingSubtext = document.getElementById('loadingSubtext');
+    const startedAt = Date.now();
+    const steps = [
+        { at: 0, text: 'Searching TPDB for matching entries...' },
+        { at: 5, text: 'Checking matching TPDB entries for available posters...' },
+        { at: 10, text: 'Trying additional matches if the first result has no posters...' },
+        { at: 15, text: 'Converting poster previews for the picker...' },
+        { at: 25, text: 'Still working. TPDB responses can take a little while...' }
+    ];
+
+    const update = () => {
+        const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+        const currentStep = [...steps].reverse().find(step => elapsed >= step.at) || steps[0];
+        if (loadingText) loadingText.textContent = 'Searching and converting posters...';
+        if (loadingSubtext) loadingSubtext.textContent = currentStep.text;
+    };
+
+    update();
+    posterSearchProgressTimer = setInterval(update, 1000);
+}
+
+function stopPosterSearchProgress() {
+    if (posterSearchProgressTimer) {
+        clearInterval(posterSearchProgressTimer);
+        posterSearchProgressTimer = null;
+    }
+
+    const loadingSubtext = document.getElementById('loadingSubtext');
+    if (loadingSubtext) loadingSubtext.textContent = 'This may take a few moments';
+}
+
 // Load posters for item
 async function loadPosters(itemId) {
     currentItemId = itemId;
-    const lt = document.getElementById('loadingText');
-    if (lt) lt.textContent = 'Searching and converting posters...';
+    startPosterSearchProgress();
     if (loadingModal) loadingModal.show();
 
     try {
@@ -171,6 +206,8 @@ async function loadPosters(itemId) {
         console.error('Error loading posters:', error);
         if (loadingModal) loadingModal.hide();
         showAlert('Failed to load posters: ' + error.message, 'danger');
+    } finally {
+        stopPosterSearchProgress();
     }
 }
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -55,7 +55,7 @@
             <span class="visually-hidden">Loading...</span>
           </div>
           <h5 id="loadingText">Loading posters...</h5>
-          <p class="text-muted mb-0">This may take a few moments</p>
+          <p class="text-muted mb-0" id="loadingSubtext">This may take a few moments</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #20
Builds upon the code from #22

This PR improves the Find Posters flow so duplicate or imperfect TPDB search results are handled more reliably.

Previously, items like **Cowboy Bebop (1998)** could fail because the first TPDB match had no posters, even though another matching Cowboy Bebop entry did have posters. The search now tries additional valid TPDB matches instead of stopping at the first result, while still respecting the item year so unrelated versions are not mixed together.

Also adds clearer progress text to the Find Posters loading popup so users can see what the app is working on while TPDB search and poster conversion are running.

### Changes

- Try multiple TPDB search candidates when the first valid match has no posters.
- Keep year matching important, avoiding mismatches like `1998` vs `2004`.
- Add progress-stage text to the Find Posters loading modal.

<img width="1546" height="1020" alt="image" src="https://github.com/user-attachments/assets/7eb323d2-3ab2-49e9-9bc0-248a7823f667" />


<img width="1529" height="685" alt="image" src="https://github.com/user-attachments/assets/7c3d28ac-6acc-4ed7-be4b-7ba7f8557bf3" />
