### PR TITLE
Improve startup and runtime logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,8 +22,16 @@ class ConsoleFormatter(logging.Formatter):
         logging.ERROR: "\033[31m",
         logging.CRITICAL: "\033[97;41m",
     }
+    VALUE = "\033[96m"
     RESET = "\033[0m"
     ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+    VALUE_PREFIXES = (
+        "Successfully uploaded poster for: ",
+        "Searching posters for: ",
+        "Processing item ",
+        "No TPDB search results for ",
+        "Found 0 poster links for ",
+    )
 
     def __init__(self, use_color=True):
         super().__init__(datefmt="%H:%M:%S")
@@ -44,8 +52,15 @@ class ConsoleFormatter(logging.Formatter):
         if self.use_color:
             color = self.COLORS.get(display_level, "")
             level = f"{color}{level}{self.RESET}"
+            message = self.highlight_value(message)
 
         return f"{timestamp} {level} {message}"
+
+    def highlight_value(self, message):
+        for prefix in self.VALUE_PREFIXES:
+            if message.startswith(prefix):
+                return f"{prefix}{self.VALUE}{message[len(prefix):]}{self.RESET}"
+        return message
 
 
 class WerkzeugAccessLogFilter(logging.Filter):

--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import uuid
 import json
 import os
 import logging
+import re
+import sys
 import time
 from datetime import datetime
 from poster_scraper import *
@@ -12,16 +14,83 @@ import threading
 app = Flask(__name__)
 app.config.from_object(Config)
 
-# Setup logging
-os.makedirs(Config.LOG_DIR, exist_ok=True)
-logging.basicConfig(
-    level=logging.INFO if not Config.DEBUG else logging.DEBUG,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(f'{Config.LOG_DIR}/app.log'),
-        logging.StreamHandler()
-    ]
-)
+class ConsoleFormatter(logging.Formatter):
+    COLORS = {
+        logging.DEBUG: "\033[90m",
+        logging.INFO: "\033[36m",
+        logging.WARNING: "\033[33m",
+        logging.ERROR: "\033[31m",
+        logging.CRITICAL: "\033[97;41m",
+    }
+    RESET = "\033[0m"
+    ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+    def __init__(self, use_color=True):
+        super().__init__(datefmt="%H:%M:%S")
+        self.use_color = use_color
+
+    def format(self, record):
+        timestamp = self.formatTime(record, self.datefmt)
+        display_level = record.levelno
+        message = record.getMessage()
+        plain_message = self.ANSI_PATTERN.sub("", message).strip()
+
+        if plain_message.startswith("WARNING:"):
+            display_level = logging.WARNING
+            message = plain_message.removeprefix("WARNING:").strip()
+
+        level = logging.getLevelName(display_level).ljust(7)
+
+        if self.use_color:
+            color = self.COLORS.get(display_level, "")
+            level = f"{color}{level}{self.RESET}"
+
+        return f"{timestamp} {level} {message}"
+
+
+class WerkzeugAccessLogFilter(logging.Filter):
+    METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
+
+    def filter(self, record):
+        if getattr(Config, "DEBUG", False):
+            return True
+
+        message = record.getMessage()
+        is_access_log = " HTTP/" in message and any(f'"{method} ' in message for method in self.METHODS)
+        return not is_access_log
+
+
+def setup_logging():
+    os.makedirs(Config.LOG_DIR, exist_ok=True)
+
+    log_level = logging.DEBUG if Config.DEBUG else logging.INFO
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.handlers.clear()
+
+    file_handler = logging.FileHandler(f'{Config.LOG_DIR}/app.log', encoding='utf-8')
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
+    ))
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(log_level)
+    console_handler.setFormatter(ConsoleFormatter(
+        use_color=sys.stderr.isatty() and os.environ.get("NO_COLOR") is None
+    ))
+
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+    werkzeug_logger = logging.getLogger("werkzeug")
+    werkzeug_logger.handlers.clear()
+    werkzeug_logger.setLevel(log_level)
+    werkzeug_logger.addFilter(WerkzeugAccessLogFilter())
+    werkzeug_logger.propagate = True
+
+
+setup_logging()
 
 # Global storage for session data
 user_sessions = {}
@@ -86,7 +155,7 @@ def index():
 
     try:
         server_info = get_jellyfin_server_info()
-        logging.info(f"Connected to server: {server_info['name']}")
+        logging.debug(f"Connected to server: {server_info['name']}")
 
         jellyfin_items = get_jellyfin_items(item_type=item_type, sort_by=sort_by)
 
@@ -162,7 +231,7 @@ def select_poster(item_id):
         return jsonify({'error': 'No poster URL provided'}), 400
 
     user_sessions[session_id]['selections'][item_id] = poster_url
-    logging.info(f"Poster selected for item {item_id}: {poster_url}")
+    logging.debug(f"Poster selected for item {item_id}: {poster_url}")
 
     return jsonify({'success': True})
 
@@ -725,12 +794,16 @@ def background_setup():
         # attempt setup on demand and return a concrete TPDB error instead of permanent 503.
         selenium_ready_event.set()
 
+
 if __name__ == '__main__':
+    host = '0.0.0.0'
+    port = 5001
+
     setup_thread = threading.Thread(target=background_setup, daemon=True)
     setup_thread.start()
 
     try:
-        app.run(debug=Config.DEBUG, host='0.0.0.0', port=5001)
+        app.run(debug=Config.DEBUG, host=host, port=port)
     except KeyboardInterrupt:
         logging.info("Shutdown requested by CTRL+C")
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -731,6 +731,8 @@ if __name__ == '__main__':
 
     try:
         app.run(debug=Config.DEBUG, host='0.0.0.0', port=5001)
+    except KeyboardInterrupt:
+        logging.info("Shutdown requested by CTRL+C")
     except Exception as e:
         logging.error(f"Failed to start Flask application: {e}")
     finally:

--- a/app.py
+++ b/app.py
@@ -170,7 +170,7 @@ def index():
 
     try:
         server_info = get_jellyfin_server_info()
-        logging.debug(f"Connected to server: {server_info['name']}")
+        logging.info(f"Connected to server: {server_info['name']}")
 
         jellyfin_items = get_jellyfin_items(item_type=item_type, sort_by=sort_by)
 

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -188,7 +188,11 @@ def setup_selenium_and_login(force=False):
                 excluded_switches.append("enable-logging")
             chrome_options.add_experimental_option("excludeSwitches", excluded_switches)
             chrome_options.add_experimental_option("useAutomationExtension", False)
-            selenium_driver = webdriver.Chrome(options=chrome_options)
+            chrome_service = None
+            if not getattr(Config, "DEBUG", False):
+                chrome_service = Service(log_output=os.devnull)
+
+            selenium_driver = webdriver.Chrome(options=chrome_options, service=chrome_service)
             selenium_driver.set_page_load_timeout(30)
             try:
                 selenium_driver.execute_cdp_cmd(

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -778,5 +778,5 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
         logging.error(f"Error fetching items from Jellyfin: {e}")
         return []
 
-    logging.debug(f"Total items fetched: {len(items)}")
+    logging.info(f"Total items fetched: {len(items)}")
     return items

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -175,6 +175,9 @@ def setup_selenium_and_login(force=False):
             if not getattr(Config, "DEBUG", False):
                 chrome_options.add_argument("--disable-logging")
                 chrome_options.add_argument("--log-level=3")
+                chrome_options.add_argument("--disable-webgpu")
+                chrome_options.add_argument("--disable-vulkan")
+                chrome_options.add_argument("--disable-features=WebGPU,Vulkan,UseSkiaRenderer")
             chrome_options.add_argument("--no-sandbox")
             chrome_options.add_argument("--disable-dev-shm-usage")
             chrome_options.add_argument("--disable-blink-features=AutomationControlled")
@@ -301,7 +304,7 @@ def download_image_with_cookies(url, save_path):
                     for chunk in response.iter_content(8192):
                         if chunk:
                             f.write(chunk)
-                logging.info(f"Saved image to {save_path}")
+                logging.debug(f"Saved image to {save_path}")
                 return True
             else:
                 logging.warning(f"Failed to download image from {url} (status {response.status_code})")
@@ -415,7 +418,7 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
 
             if tmdb_title:
                 search_query = f'{tmdb_title} ({year})' if year else tmdb_title
-                logging.info(f"Using TMDB title for TPDB search: {search_query}")
+                logging.debug(f"Using TMDB title for TPDB search: {search_query}")
         except Exception as e:
             logging.warning(f"TMDB lookup failed for {item_title} ({item_type}): {e}; falling back to Jellyfin title.")
 
@@ -428,7 +431,7 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
     elif item_type == "Series":
         search_url += "&section=shows"
 
-    logging.info(f"TPDB search URL: {search_url}")
+    logging.debug(f"TPDB search URL: {search_url}")
 
     try:
         poster_urls = []
@@ -516,7 +519,10 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
                     continue
                 raise
 
-        logging.info(f"Found {len(poster_urls)} poster links; converting to base64 for preview")
+        if poster_urls:
+            logging.info(f"Found {len(poster_urls)} poster links; converting to base64 for preview")
+        else:
+            logging.warning("Found 0 poster links for '%s'.", item_title)
         poster_data = []
         for i, poster_url in enumerate(poster_urls):
             base64_image = get_image_as_base64(poster_url)
@@ -591,12 +597,12 @@ def upload_image_to_jellyfin_improved(item_id, image_path):
     """Upload image to Jellyfin with improved logic"""
     try:
         if not os.path.exists(image_path):
-            print(f"Image file not found: {image_path}")
+            logging.warning(f"Image file not found: {image_path}")
             return False
 
         # Check if images are identical
         if are_images_identical(item_id, image_path, 'Primary'):
-            print(f"Image for item {item_id} is identical to existing.")
+            logging.info(f"Image for item {item_id} is identical to existing.")
             return True
 
         # Read and encode the image
@@ -617,14 +623,14 @@ def upload_image_to_jellyfin_improved(item_id, image_path):
         response = requests.post(url, headers=headers, data=encoded_data, timeout=30)
 
         if response.status_code in [200, 204]:
-            print("Artwork uploaded successfully!")
+            logging.info("Artwork uploaded successfully.")
             return True
         else:
-            print(f"Failed to upload artwork: {response.status_code}")
+            logging.warning(f"Failed to upload artwork: {response.status_code}")
             return False
 
     except Exception as e:
-        print(f"Error during image upload: {e}")
+        logging.error(f"Error during image upload: {e}")
         return False
     finally:
         # Clean up memory
@@ -673,7 +679,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
 
     try:
         if sort_by == 'date_added':
-            logging.info("Fetching all items for chronological sorting (mixed types).")
+            logging.debug("Fetching all items for chronological sorting (mixed types).")
             all_items_url = (
                 f"{Config.JELLYFIN_URL}/Items"
                 f"?IncludeItemTypes=Movie,Series&Recursive=true"
@@ -772,5 +778,5 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
         logging.error(f"Error fetching items from Jellyfin: {e}")
         return []
 
-    logging.info(f"Total items fetched: {len(items)}")
+    logging.debug(f"Total items fetched: {len(items)}")
     return items

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -236,16 +236,27 @@ def setup_selenium_and_login(force=False):
                 teardown_selenium()
             raise
 
-def teardown_selenium():
-    """Shutdown Selenium driver (only used on app shutdown)."""
+def teardown_selenium(timeout=5):
+    """Shutdown Selenium driver without letting a stuck ChromeDriver block app exit."""
     global selenium_driver
     with selenium_lock:
-        if selenium_driver:
-            try:
-                selenium_driver.quit()
-            except Exception:
-                pass
-            selenium_driver = None
+        driver = selenium_driver
+        selenium_driver = None
+
+    if not driver:
+        return
+
+    def quit_driver():
+        try:
+            driver.quit()
+        except Exception as shutdown_error:
+            logging.warning(f"Failed to shutdown Selenium driver cleanly: {shutdown_error}")
+
+    cleanup_thread = threading.Thread(target=quit_driver, daemon=True)
+    cleanup_thread.start()
+    cleanup_thread.join(timeout)
+    if cleanup_thread.is_alive():
+        logging.warning("Selenium driver shutdown is still running; continuing application exit.")
 
 def get_selenium_cookies_as_dict():
     """Return Selenium cookies as a dict for requests.Session."""

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -431,7 +431,7 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
     elif item_type == "Series":
         search_url += "&section=shows"
 
-    logging.debug(f"TPDB search URL: {search_url}")
+    logging.info(f"TPDB search URL: {search_url}")
 
     try:
         poster_urls = []

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -172,6 +172,9 @@ def setup_selenium_and_login(force=False):
             chrome_options.add_argument("--headless=new")
             chrome_options.add_argument("--window-size=1920,1080")
             chrome_options.add_argument("--disable-gpu")
+            if not getattr(Config, "DEBUG", False):
+                chrome_options.add_argument("--disable-logging")
+                chrome_options.add_argument("--log-level=3")
             chrome_options.add_argument("--no-sandbox")
             chrome_options.add_argument("--disable-dev-shm-usage")
             chrome_options.add_argument("--disable-blink-features=AutomationControlled")
@@ -180,7 +183,10 @@ def setup_selenium_and_login(force=False):
                 "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
             )
-            chrome_options.add_experimental_option("excludeSwitches", ["enable-automation"])
+            excluded_switches = ["enable-automation"]
+            if not getattr(Config, "DEBUG", False):
+                excluded_switches.append("enable-logging")
+            chrome_options.add_experimental_option("excludeSwitches", excluded_switches)
             chrome_options.add_experimental_option("useAutomationExtension", False)
             selenium_driver = webdriver.Chrome(options=chrome_options)
             selenium_driver.set_page_load_timeout(30)


### PR DESCRIPTION
This PR makes the terminal output slightly easier to read while also improving CTRL+C behavior.

- Adds a lightweight console formatter with shorter timestamps and colored log levels.
- Suppresses noisy Werkzeug request/access logs when `DEBUG = False`, such as static asset and image proxy requests.
- Normalizes Flask’s development-server warning so it appears as a proper warning instead of `INFO WARNING`.
- Moves lower-value technical details like temp poster paths and routine item counts to `DEBUG`.
- Converts raw upload `print()` messages to proper timestamped log entries.
- Adds minimal terminal highlighting for useful item names/status values, such as successful poster uploads.
- Reduces Chrome/ChromeDriver startup noise in normal mode while preserving debug visibility where possible.

<img width="1058" height="362" alt="image" src="https://github.com/user-attachments/assets/f9d15564-f2f4-4088-9ed8-57a803c8ed20" />
