### PR TITLE
Make library filters client-side and show visible counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,8 +79,10 @@ def index():
         session_id = str(uuid.uuid4())
         session['session_id'] = session_id
 
-    # Accept 'movies' or 'series' or None
+    # Accept 'movies' or 'series' for the client-side visual filter.
     item_type = request.args.get('type', None)
+    if item_type not in ('movies', 'series'):
+        item_type = None
     # 'name', 'year', 'date_added'
     sort_by = request.args.get('sort', 'name')
 
@@ -88,7 +90,7 @@ def index():
         server_info = get_jellyfin_server_info()
         logging.info(f"Connected to server: {server_info['name']}")
 
-        jellyfin_items = get_jellyfin_items(item_type=item_type, sort_by=sort_by)
+        jellyfin_items = get_jellyfin_items(sort_by=sort_by)
 
         # Store in session
         user_sessions[session_id] = {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -86,19 +86,14 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize counters/buttons
     updateUploadAllButton();
 
-    // If URL has filter param, apply it on load
     const urlParams = new URLSearchParams(window.location.search);
-    const currentFilter = urlParams.get('type') || 'all';
-    if (currentFilter !== 'all') {
-        filterContent(currentFilter);
-    }
+    filterContent(urlParams.get('type') || 'all', false);
 
     console.log('Jellyfin Poster Manager initialized');
 });
 
 // Filter and Sort Functions
-function filterContent(type) {
-    // Normalize to DOM data-type values
+function filterContent(type, updateUrl = true) {
     let domType = type;
     if (type === 'movies') domType = 'movie';
     if (type === 'series') domType = 'series';
@@ -116,16 +111,28 @@ function filterContent(type) {
         }
     });
 
-    const totalCount = document.getElementById('totalItemCount');
-    if (totalCount) totalCount.textContent = visibleCount;
+    const visibleItemCount = document.getElementById('visibleItemCount');
+    if (visibleItemCount) visibleItemCount.textContent = visibleCount;
 
-    // Update URL without reload to persist filter
+    const itemCountTotalText = document.getElementById('itemCountTotalText');
+    const allItemCount = Number(document.getElementById('allItemCount')?.dataset.count || items.length);
+    if (itemCountTotalText) {
+        itemCountTotalText.innerHTML = type === 'all' ? '' : ` of <strong>${allItemCount}</strong>`;
+    }
+
+    const filterId = type === 'movies' ? 'filterMovies' : type === 'series' ? 'filterSeries' : 'filterAll';
+    const filterInput = document.getElementById(filterId);
+    if (filterInput) filterInput.checked = true;
+
+    if (!updateUrl) return;
+
     const url = new URL(window.location);
     if (type === 'all') {
         url.searchParams.delete('type');
     } else {
         url.searchParams.set('type', type); // keep 'movies'/'series'
     }
+    url.hash = '';
     window.history.pushState({}, '', url);
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,10 @@
                             {{ server_info.name }} Library
                         </h1>
                         <p class="text-muted mb-0">
-                            Found <strong><span id="totalItemCount">{{ items|length }}</span></strong> items.
+                            <span id="itemCountSummary">
+                                Showing <strong><span id="visibleItemCount">{{ items|length }}</span></strong><span id="itemCountTotalText"></span> items.
+                            </span>
+                            <span id="allItemCount" data-count="{{ items|length }}" class="d-none"></span>
                             {% if server_info.version %}
                             <small class="ms-2">
                                 <i class="fas fa-server me-1"></i>


### PR DESCRIPTION
This PR improves the Movies/Series/All tab behavior so switching between library types no longer refetches the Jellyfin library from the server.

- Makes `?type=movies` and `?type=series` control the visual client-side filter instead of changing what the backend loads.
- Updates the library count text to show filtered context:
  - `Showing 654 items.`
  - `Showing 288 of 654 items.`

Server-side type filtering caused empty results when switching tabs from a URL like `?type=series`, because the page only had series cards loaded. Loading the full library once and filtering visually keeps the UI responsive while preserving URL state.