### PR TITLE
Add Jellyfin library filtering and library-based sorting

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,14 +83,19 @@ def index():
     item_type = request.args.get('type', None)
     if item_type not in ('movies', 'series'):
         item_type = None
-    # 'name', 'year', 'date_added'
-    sort_by = request.args.get('sort', 'name')
+    current_library = request.args.get('library', None)
+    # 'library', 'name', 'year', 'date_added'
+    sort_by = request.args.get('sort', 'library')
 
     try:
         server_info = get_jellyfin_server_info()
         logging.info(f"Connected to server: {server_info['name']}")
 
-        jellyfin_items = get_jellyfin_items(sort_by=sort_by)
+        jellyfin_libraries = get_jellyfin_libraries()
+        jellyfin_items = get_jellyfin_items(sort_by=sort_by, libraries=jellyfin_libraries)
+        library_ids = {library['id'] for library in jellyfin_libraries}
+        if current_library not in library_ids:
+            current_library = None
 
         # Store in session
         user_sessions[session_id] = {
@@ -103,17 +108,21 @@ def index():
 
         return render_template('index.html',
                                items=jellyfin_items,
+                               libraries=jellyfin_libraries,
                                server_info=server_info,
                                current_filter=item_type,
+                               current_library=current_library,
                                current_sort=sort_by)
 
     except Exception as e:
         logging.error(f"Error loading main page: {e}")
         return render_template('index.html',
                                items=[],
+                               libraries=[],
                                server_info={'name': 'Jellyfin Server', 'version': '', 'id': ''},
                                error=str(e),
                                current_filter=item_type,
+                               current_library=current_library,
                                current_sort=sort_by)
 
 @app.route('/item/<item_id>/posters')
@@ -437,6 +446,7 @@ def batch_auto_poster():
 
         data = request.get_json() or {}
         target_filter = data.get('filter', 'no-poster')  # 'all', 'no-poster', 'movies', 'series'
+        library_id = data.get('library_id') or ''
 
         logging.info(f"Starting batch auto-poster operation with filter: {target_filter}")
 

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -626,7 +626,35 @@ def get_jellyfin_server_info():
         logging.error(f"Error fetching server info: {e}")
         return {'name': 'Jellyfin Server', 'version': '', 'id': ''}
 
-def get_jellyfin_items(item_type=None, sort_by='name'):
+
+def get_jellyfin_libraries():
+    if not Config.JELLYFIN_URL or not Config.JELLYFIN_API_KEY:
+        return []
+
+    headers = {"X-Emby-Token": Config.JELLYFIN_API_KEY}
+    try:
+        response = requests.get(f"{Config.JELLYFIN_URL}/Library/VirtualFolders", headers=headers, timeout=10)
+        response.raise_for_status()
+        libraries = []
+        for library in response.json():
+            library_id = library.get('ItemId')
+            library_name = library.get('Name')
+            library_type = library.get('CollectionType', '')
+            if library_type == 'boxsets' or (library_name or '').strip().lower() == 'collections':
+                continue
+            if library_id and library_name:
+                libraries.append({
+                    'id': library_id,
+                    'name': library_name,
+                    'type': library_type
+                })
+        return libraries
+    except Exception as e:
+        logging.warning(f"Could not fetch Jellyfin libraries: {e}")
+        return []
+
+
+def get_jellyfin_items(item_type=None, sort_by='name', libraries=None):
     """
     Fetch a list of movies and TV shows from Jellyfin with thumbnail URLs.
     item_type: 'movies', 'series', or None for both
@@ -641,6 +669,33 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
         "X-Emby-Token": Config.JELLYFIN_API_KEY,
         "Accept": "application/json",
     }
+    libraries = libraries if libraries is not None else get_jellyfin_libraries()
+    library_names = {library['id']: library['name'] for library in libraries}
+
+    def build_item(item, item_type_label, fallback_library=None):
+        ancestor_ids = item.get('AncestorIds') or []
+        library_id = item.get('ParentId', '')
+        if library_id not in library_names:
+            library_id = next((ancestor_id for ancestor_id in ancestor_ids if ancestor_id in library_names), '')
+        if not library_id and fallback_library:
+            library_id = fallback_library.get('id', '')
+        thumbnail_url = None
+        if item.get('ImageTags', {}).get('Primary'):
+            thumbnail_url = (
+                f"{Config.JELLYFIN_URL}/Items/{item.get('Id')}/Images/Primary"
+                f"?maxWidth=300&quality=85&tag={item['ImageTags']['Primary']}"
+            )
+        return {
+            "id": item.get('Id'),
+            "title": item.get('Name'),
+            "year": item.get('ProductionYear'),
+            "type": item_type_label,
+            "thumbnail_url": thumbnail_url,
+            "date_created": item.get('DateCreated', ''),
+            "library_id": library_id,
+            "library_name": library_names.get(library_id, fallback_library.get('name', '') if fallback_library else ''),
+            'ProviderIds': item.get('ProviderIds', {})
+        }
 
     sort_params = {
         'name': 'SortName',
@@ -651,12 +706,52 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
     sort_order = 'Descending' if sort_by == 'date_added' else 'Ascending'
 
     try:
+        if libraries:
+            include_types = "Movie,Series"
+            if item_type == 'movies':
+                include_types = "Movie"
+            elif item_type == 'series':
+                include_types = "Series"
+
+            for library in libraries:
+                library_items_url = (
+                    f"{Config.JELLYFIN_URL}/Items"
+                    f"?ParentId={library['id']}"
+                    f"&IncludeItemTypes={include_types}&Recursive=true"
+                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,Type,ParentId,AncestorIds"
+                )
+                response = requests.get(library_items_url, headers=headers, timeout=15)
+                response.raise_for_status()
+                library_data = response.json()
+                for item in library_data.get('Items', []):
+                    item_type_label = "Movie" if item.get('Type') == 'Movie' else "Series"
+                    items.append(build_item(item, item_type_label, fallback_library=library))
+
+            if sort_by == 'library':
+                items.sort(key=lambda x: ((x.get('library_name') or '').lower(), (x.get('title') or '').lower()))
+            elif sort_by == 'year':
+                items.sort(key=lambda x: ((x.get('year') or 0), (x.get('title') or '').lower()))
+            elif sort_by == 'date_added':
+                def parse_date(date_str):
+                    if not date_str:
+                        return datetime.min
+                    try:
+                        return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+                    except Exception:
+                        return datetime.min
+                items.sort(key=lambda x: parse_date(x['date_created']), reverse=True)
+            else:
+                items.sort(key=lambda x: (x.get('title') or '').lower())
+
+            logging.info(f"Total items fetched: {len(items)}")
+            return items
+
         if sort_by == 'date_added':
             logging.info("Fetching all items for chronological sorting (mixed types).")
             all_items_url = (
                 f"{Config.JELLYFIN_URL}/Items"
                 f"?IncludeItemTypes=Movie,Series&Recursive=true"
-                f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,Type"
+                f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,Type,ParentId,AncestorIds"
                 f"&SortBy={sort_by_param}&SortOrder={sort_order}"
             )
             response = requests.get(all_items_url, headers=headers, timeout=15)
@@ -665,21 +760,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
 
             if 'Items' in all_data:
                 for item in all_data['Items']:
-                    thumbnail_url = None
-                    if item.get('ImageTags', {}).get('Primary'):
-                        thumbnail_url = (
-                            f"{Config.JELLYFIN_URL}/Items/{item.get('Id')}/Images/Primary"
-                            f"?maxWidth=300&quality=85&tag={item['ImageTags']['Primary']}"
-                        )
-                    items.append({
-                        "id": item.get('Id'),
-                        "title": item.get('Name'),
-                        "year": item.get('ProductionYear'),
-                        "type": "Movie" if item.get('Type') == 'Movie' else "Series",
-                        "thumbnail_url": thumbnail_url,
-                        "date_created": item.get('DateCreated', ''),
-                        'ProviderIds': item.get('ProviderIds', {})
-                    })
+                    items.append(build_item(item, "Movie" if item.get('Type') == 'Movie' else "Series"))
             # Python-side sort for safety
             from datetime import datetime
             def parse_date(date_str):
@@ -697,56 +778,28 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
                 movies_url = (
                     f"{Config.JELLYFIN_URL}/Items"
                     f"?IncludeItemTypes=Movie&Recursive=true"
-                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated"
+                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,ParentId,AncestorIds"
                     f"&SortBy={sort_by_param}&SortOrder={sort_order}"
                 )
                 response = requests.get(movies_url, headers=headers, timeout=15)
                 response.raise_for_status()
                 movies_data = response.json()
                 for item in movies_data.get('Items', []):
-                    thumbnail_url = None
-                    if item.get('ImageTags', {}).get('Primary'):
-                        thumbnail_url = (
-                            f"{Config.JELLYFIN_URL}/Items/{item.get('Id')}/Images/Primary"
-                            f"?maxWidth=300&quality=85&tag={item['ImageTags']['Primary']}"
-                        )
-                    items.append({
-                        "id": item.get('Id'),
-                        "title": item.get('Name'),
-                        "year": item.get('ProductionYear'),
-                        "type": "Movie",
-                        "thumbnail_url": thumbnail_url,
-                        "date_created": item.get('DateCreated', ''),
-                        'ProviderIds': item.get('ProviderIds', {})
-                    })
+                    items.append(build_item(item, "Movie"))
 
             # Series
             if item_type == 'series' or item_type is None:
                 shows_url = (
                     f"{Config.JELLYFIN_URL}/Items"
                     f"?IncludeItemTypes=Series&Recursive=true"
-                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated"
+                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,ParentId,AncestorIds"
                     f"&SortBy={sort_by_param}&SortOrder={sort_order}"
                 )
                 response = requests.get(shows_url, headers=headers, timeout=15)
                 response.raise_for_status()
                 shows_data = response.json()
                 for item in shows_data.get('Items', []):
-                    thumbnail_url = None
-                    if item.get('ImageTags', {}).get('Primary'):
-                        thumbnail_url = (
-                            f"{Config.JELLYFIN_URL}/Items/{item.get('Id')}/Images/Primary"
-                            f"?maxWidth=300&quality=85&tag={item['ImageTags']['Primary']}"
-                        )
-                    items.append({
-                        "id": item.get('Id'),
-                        "title": item.get('Name'),
-                        "year": item.get('ProductionYear'),
-                        "type": "Series",
-                        "thumbnail_url": thumbnail_url,
-                        "date_created": item.get('DateCreated', ''),
-                        'ProviderIds': item.get('ProviderIds', {})
-                    })
+                    items.append(build_item(item, "Series"))
     except Exception as e:
         logging.error(f"Error fetching items from Jellyfin: {e}")
         return []

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -62,6 +62,9 @@ body {
 /* Buttons */
 .btn { border-radius: var(--border-radius-sm); font-weight: 500; padding: 0.5rem 1rem; transition: var(--transition); border: none; cursor: pointer; }
 .btn:hover { transform: translateY(-1px); box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+.btn-group .btn:hover {
+    transform: none;
+}
 .btn-primary { background: linear-gradient(135deg, var(--primary-color) 0%, #0056b3 100%); color: #fff; }
 .btn-success { background: linear-gradient(135deg, var(--success-color) 0%, #1e7e34 100%); color: #fff; }
 .btn-warning { background: linear-gradient(135deg, var(--warning-color) 0%, #e0a800 100%); color: #212529; }
@@ -88,6 +91,7 @@ body {
 
 /* Hide/Show by filter */
 .item-card-wrapper.hidden { display: none !important; }
+.library-group-header.hidden { display: none !important; }
 
 /* Selected counter */
 #selectedCount { font-weight: 600; color: var(--primary-color); }
@@ -111,6 +115,21 @@ body {
 .dropdown-menu { z-index: 1060; background: var(--surface); color: var(--app-text); border: 1px solid var(--border-color); }
 .dropdown-item { color: var(--app-text); }
 .dropdown-item:hover, .dropdown-item:focus { background: var(--surface-muted); color: var(--app-text); }
+.form-select {
+    background-color: var(--surface);
+    color: var(--app-text);
+    border-color: var(--border-color);
+}
+.form-select:focus {
+    background-color: var(--surface);
+    color: var(--app-text);
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.18);
+}
+.form-select option {
+    background-color: var(--surface);
+    color: var(--app-text);
+}
 
 /* Alerts */
 .alert { border: none; border-radius: var(--border-radius); padding: 1rem 1.5rem; margin-bottom: 1rem; border-left: 4px solid; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -87,6 +87,8 @@ document.addEventListener('DOMContentLoaded', function() {
     updateUploadAllButton();
 
     const urlParams = new URLSearchParams(window.location.search);
+    const libraryFilter = document.getElementById('libraryFilter');
+    if (libraryFilter) libraryFilter.value = urlParams.get('library') || '';
     filterContent(urlParams.get('type') || 'all', false);
 
     console.log('Jellyfin Poster Manager initialized');
@@ -99,16 +101,28 @@ function filterContent(type, updateUrl = true) {
     if (type === 'series') domType = 'series';
 
     const items = document.querySelectorAll('.item-card-wrapper');
+    const selectedLibrary = document.getElementById('libraryFilter')?.value || '';
     let visibleCount = 0;
 
     items.forEach(item => {
         const itemType = item.getAttribute('data-type');
-        if (type === 'all' || itemType === domType) {
+        const itemLibrary = item.getAttribute('data-library-id') || '';
+        const matchesType = type === 'all' || itemType === domType;
+        const matchesLibrary = !selectedLibrary || itemLibrary === selectedLibrary;
+        if (matchesType && matchesLibrary) {
             item.classList.remove('hidden');
             visibleCount++;
         } else {
             item.classList.add('hidden');
         }
+    });
+
+    document.querySelectorAll('.library-group-header').forEach(header => {
+        const headerLibrary = header.getAttribute('data-library-id') || '';
+        const hasVisibleItems = Array.from(items).some(item =>
+            !item.classList.contains('hidden') && (item.getAttribute('data-library-id') || '') === headerLibrary
+        );
+        header.classList.toggle('hidden', !hasVisibleItems);
     });
 
     const visibleItemCount = document.getElementById('visibleItemCount');
@@ -117,7 +131,7 @@ function filterContent(type, updateUrl = true) {
     const itemCountTotalText = document.getElementById('itemCountTotalText');
     const allItemCount = Number(document.getElementById('allItemCount')?.dataset.count || items.length);
     if (itemCountTotalText) {
-        itemCountTotalText.innerHTML = type === 'all' ? '' : ` of <strong>${allItemCount}</strong>`;
+        itemCountTotalText.innerHTML = type === 'all' && !selectedLibrary ? '' : ` of <strong>${allItemCount}</strong>`;
     }
 
     const filterId = type === 'movies' ? 'filterMovies' : type === 'series' ? 'filterSeries' : 'filterAll';
@@ -132,8 +146,19 @@ function filterContent(type, updateUrl = true) {
     } else {
         url.searchParams.set('type', type); // keep 'movies'/'series'
     }
+    if (selectedLibrary) {
+        url.searchParams.set('library', selectedLibrary);
+    } else {
+        url.searchParams.delete('library');
+    }
     url.hash = '';
     window.history.pushState({}, '', url);
+}
+
+function filterLibrary() {
+    const currentType = document.querySelector('input[name="contentFilter"]:checked')?.id;
+    const type = currentType === 'filterMovies' ? 'movies' : currentType === 'filterSeries' ? 'series' : 'all';
+    filterContent(type);
 }
 
 function sortContent(sortBy) {
@@ -516,8 +541,11 @@ async function startAutoBatchPoster(filter) {
             'movies': 'Automatically find and upload posters for all Movies?',
             'series': 'Automatically find and upload posters for all Series?'
         }[filter] || 'Start automatic poster upload?';
+        const librarySelect = document.getElementById('libraryFilter');
+        const libraryId = librarySelect?.value || '';
+        const libraryName = libraryId ? librarySelect.options[librarySelect.selectedIndex]?.text : '';
 
-        if (!confirm(confirmText)) return;
+        if (!confirm(libraryName ? `${confirmText}\n\nLibrary: ${libraryName}` : confirmText)) return;
 
         const autoBtn = document.getElementById('autoPosterBtn');
         if (autoBtn) {
@@ -532,7 +560,7 @@ async function startAutoBatchPoster(filter) {
         const resp = await fetch('/batch-auto-poster', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ filter })
+            body: JSON.stringify({ filter, library_id: libraryId })
         });
 
         const data = await resp.json();

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,41 +58,6 @@
     </div>
 </div>
 
-<!-- Sort Dropdown Row -->
-<div class="row mb-4">
-    <div class="col-12 d-flex justify-content-end">
-        <div class="dropdown">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button"
-                    id="sortDropdownBtn" data-bs-toggle="dropdown" aria-expanded="false" data-bs-boundary="viewport">
-                <i class="fas fa-sort me-1"></i>
-                Sort by
-            </button>
-            <ul class="dropdown-menu" aria-labelledby="sortDropdownBtn">
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'library' else '' }}" href="#" onclick="sortContent('library')">
-                        <i class="fas fa-folder me-2"></i>Library
-                    </a>
-                </li>
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'name' else '' }}" href="#" onclick="sortContent('name')">
-                        <i class="fas fa-sort-alpha-down me-2"></i>Name (A-Z)
-                    </a>
-                </li>
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'year' else '' }}" href="#" onclick="sortContent('year')">
-                        <i class="fas fa-calendar me-2"></i>Year
-                    </a>
-                </li>
-                <li>
-                    <a class="dropdown-item {{ 'active' if current_sort == 'date_added' else '' }}" href="#" onclick="sortContent('date_added')">
-                        <i class="fas fa-clock me-2"></i>Recently Added
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
-
 <!-- Manual Selection -->
 <div class="row mb-3">
     <div class="col-12">
@@ -181,6 +146,41 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+</div>
+
+<!-- Grid Tools -->
+<div class="row mb-4">
+    <div class="col-12 d-flex flex-wrap justify-content-end gap-2">
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button"
+                    id="sortDropdownBtn" data-bs-toggle="dropdown" aria-expanded="false" data-bs-boundary="viewport">
+                <i class="fas fa-sort me-1"></i>
+                Sort by
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="sortDropdownBtn">
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'library' else '' }}" href="#" onclick="sortContent('library')">
+                        <i class="fas fa-folder me-2"></i>Library
+                    </a>
+                </li>
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'name' else '' }}" href="#" onclick="sortContent('name')">
+                        <i class="fas fa-sort-alpha-down me-2"></i>Name (A-Z)
+                    </a>
+                </li>
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'year' else '' }}" href="#" onclick="sortContent('year')">
+                        <i class="fas fa-calendar me-2"></i>Year
+                    </a>
+                </li>
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'date_added' else '' }}" href="#" onclick="sortContent('date_added')">
+                        <i class="fas fa-clock me-2"></i>Recently Added
+                    </a>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,16 @@
                                 <i class="fas fa-tv me-1"></i>Series
                             </label>
                         </div>
+                        {% if libraries %}
+                        <select class="form-select form-select-sm mt-2" id="libraryFilter" onchange="filterLibrary()" aria-label="Filter Jellyfin library">
+                            <option value="">All Libraries</option>
+                            {% for library in libraries %}
+                            <option value="{{ library.id }}" {{ 'selected' if current_library == library.id else '' }}>
+                                {{ library.name }}
+                            </option>
+                            {% endfor %}
+                        </select>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -58,6 +68,11 @@
                 Sort by
             </button>
             <ul class="dropdown-menu" aria-labelledby="sortDropdownBtn">
+                <li>
+                    <a class="dropdown-item {{ 'active' if current_sort == 'library' else '' }}" href="#" onclick="sortContent('library')">
+                        <i class="fas fa-folder me-2"></i>Library
+                    </a>
+                </li>
                 <li>
                     <a class="dropdown-item {{ 'active' if current_sort == 'name' else '' }}" href="#" onclick="sortContent('name')">
                         <i class="fas fa-sort-alpha-down me-2"></i>Name (A-Z)
@@ -172,10 +187,21 @@
 
 <!-- Items Grid -->
 <div class="row" id="itemsGrid">
+    {% set library_group = namespace(current='') %}
     {% for item in items %}
+    {% if current_sort == 'library' and item.library_id != library_group.current %}
+    {% set library_group.current = item.library_id %}
+    <div class="col-12 library-group-header" data-library-id="{{ item.library_id or '' }}">
+        <h6 class="mb-3 mt-2 text-muted">
+            <i class="fas fa-folder me-2"></i>{{ item.library_name or 'Unknown Library' }}
+        </h6>
+    </div>
+    {% endif %}
     <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 mb-4 item-card-wrapper"
-         data-item-id="{{ item.id }}"
-         data-type="{{ item.type.lower() }}">
+          data-item-id="{{ item.id }}"
+          data-type="{{ item.type.lower() }}"
+          data-library-id="{{ item.library_id or '' }}"
+          data-library-name="{{ item.library_name or '' }}">
         <div class="card h-100 item-card">
             <div class="card-img-top-wrapper">
                 {% if item.thumbnail_url %}


### PR DESCRIPTION
This PR adds support for filtering the main poster list by Jellyfin library in addition to the existing All / Movies / Series content-type filters.

- Adds a Jellyfin library dropdown with entries like Anime, Series, and K-Dramas.
- Excludes the Jellyfin Collections library from the filter list.
- Loads items per Jellyfin library so each item can be reliably mapped to its source library.
- Combines filters client-side:
  - All / Movies / Series
  - Selected Jellyfin library
- Persists the selected library in the URL with `?library=...`.
- Updates visible item counts for combined filters.
- Sends the selected library to Auto-Get Posters so batch runs can target that library.
- Adds `Sort by Library` as the default sort.
- Groups the list with small library headers when sorting by library.
- Sorts items inside each library group A-Z.
- Prevents segmented filter buttons from lifting on hover.

<img width="1699" height="1141" alt="image" src="https://github.com/user-attachments/assets/fb1de6a0-dd10-4f7d-80b2-41ba9c07fa89" />
