### PR TITLE
Add season poster support

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,13 +74,15 @@ def _sweep_stale_temp_posters(max_age_sec=3600):
         logging.info("Removed %d stale temp poster files.", removed_count)
 
 
-def _create_auto_batch_job(target_filter, skip_processed=False):
+def _create_auto_batch_job(target_filter, skip_processed=False, include_season_posters=False, replace_existing_season_posters=False):
     job_id = str(uuid.uuid4())
     now = datetime.utcnow().isoformat(timespec='seconds') + 'Z'
     job = {
         'job_id': job_id,
         'filter': target_filter,
         'skip_processed': skip_processed,
+        'include_season_posters': include_season_posters,
+        'replace_existing_season_posters': replace_existing_season_posters,
         'status': 'starting',
         'phase': 'starting',
         'message': 'Starting automatic poster batch...',
@@ -375,6 +377,109 @@ def _find_jellyfin_item(item_id):
     return next((current_item for current_item in get_jellyfin_items() if current_item.get('id') == item_id), None)
 
 
+def _safe_filename_part(value):
+    return "".join(c for c in (value or "item") if c.isalnum() or c in " _-").rstrip() or "item"
+
+
+def _upload_poster_url_to_jellyfin_item(target_id, poster_url, filename_prefix, title):
+    safe_title = _safe_filename_part(title)
+    save_path = os.path.join(Config.TEMP_POSTER_DIR, f"{filename_prefix}_{safe_title}_{target_id}.jpg")
+    if not download_image_with_cookies(poster_url, save_path):
+        return False
+    try:
+        return upload_image_to_jellyfin_improved(target_id, save_path)
+    finally:
+        try:
+            if os.path.exists(save_path):
+                os.remove(save_path)
+        except Exception as cleanup_error:
+            logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
+
+
+def _normalize_selection(selection):
+    if isinstance(selection, str):
+        return {
+            'type': 'single',
+            'series_poster_url': selection,
+            'season_posters': {},
+        }
+    if isinstance(selection, dict):
+        return {
+            'type': selection.get('type') or 'series_group',
+            'series_poster_url': selection.get('series_poster_url') or selection.get('poster_url'),
+            'season_posters': selection.get('season_posters') or {},
+        }
+    return {'type': 'single', 'series_poster_url': None, 'season_posters': {}}
+
+
+def _upload_selection_to_jellyfin(item, selection, operation='manual-upload'):
+    normalized = _normalize_selection(selection)
+    item_id = item.get('id')
+    item_title = item.get('title', 'Unknown')
+    primary_url = normalized.get('series_poster_url')
+    season_posters = normalized.get('season_posters') or {}
+    errors = []
+    season_results = []
+    uploaded_any = False
+
+    os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
+    _sweep_stale_temp_posters()
+
+    if primary_url:
+        logging.info(f"Uploading poster to Jellyfin for {item_title}")
+        if _upload_poster_url_to_jellyfin_item(item_id, primary_url, operation, item_title):
+            uploaded_any = True
+            _log_processed_item(item, operation=operation, poster_url=primary_url)
+        else:
+            errors.append('Failed to upload series poster')
+            _log_failed_item(item, 'Failed to upload series poster', operation=operation, poster_url=primary_url)
+
+    for season_id, season_selection in season_posters.items():
+        season_url = season_selection.get('url') if isinstance(season_selection, dict) else season_selection
+        season_title = season_selection.get('title') if isinstance(season_selection, dict) else f"Season {season_id}"
+        if not season_id or not season_url:
+            continue
+        if _upload_poster_url_to_jellyfin_item(season_id, season_url, operation, f"{item_title}_{season_title}"):
+            uploaded_any = True
+            season_results.append({'season_id': season_id, 'season_title': season_title, 'success': True, 'poster_url': season_url})
+        else:
+            error = f"Failed to upload {season_title}"
+            errors.append(error)
+            season_results.append({'season_id': season_id, 'season_title': season_title, 'success': False, 'poster_url': season_url, 'error': error})
+
+    return {
+        'success': uploaded_any and not errors,
+        'uploaded_any': uploaded_any,
+        'error': '; '.join(errors) if errors else None,
+        'poster_url': primary_url,
+        'season_results': season_results,
+    }
+
+
+def _selection_from_poster_group(group, replace_existing_season_posters=False):
+    show_posters = group.get('show_posters') or []
+    selection = {
+        'type': 'series_group',
+        'series_poster_url': show_posters[0].get('url') if show_posters else None,
+        'season_posters': {},
+    }
+
+    for poster in group.get('season_posters') or []:
+        season_id = poster.get('season_id')
+        if not season_id:
+            continue
+        if poster.get('season_has_poster') and not replace_existing_season_posters:
+            continue
+        if season_id in selection['season_posters']:
+            continue
+        selection['season_posters'][season_id] = {
+            'url': poster.get('url'),
+            'title': poster.get('season_title') or 'Season',
+        }
+
+    return selection
+
+
 def _auto_fetch_and_upload_item(item, operation='retry-auto-poster'):
     item_id = item['id']
     item_title = item['title']
@@ -506,20 +611,32 @@ def get_item_posters(item_id):
 
     try:
         logging.info(f"Searching posters for: {item['title']}")
-        posters = search_tpdb_for_posters_multiple(
+        eligible_seasons = get_jellyfin_seasons(item['id']) if item.get('type') == 'Series' else []
+        poster_set_limit = request.args.get('set_limit', default=3, type=int)
+        poster_set_limit = max(1, min(poster_set_limit or 3, Config.MAX_POSTERS_PER_ITEM))
+        search_result = search_tpdb_for_poster_groups(
             item['title'],
-            item.get('year'),
-            item.get('type'),
+            item_year=item.get('year'),
+            item_type=item.get('type'),
             tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
-            max_posters=Config.MAX_POSTERS_PER_ITEM
+            eligible_seasons=eligible_seasons,
+            max_posters=poster_set_limit if item.get('type') == 'Series' else Config.MAX_POSTERS_PER_ITEM,
         )
-        return jsonify({'item': item, 'posters': posters})
+        return jsonify({
+            'item': item,
+            'posters': search_result.get('posters', []),
+            'poster_groups': search_result.get('groups', []),
+            'eligible_seasons': eligible_seasons,
+            'poster_set_limit': poster_set_limit,
+            'can_browse_more_sets': item.get('type') == 'Series' and poster_set_limit < Config.MAX_POSTERS_PER_ITEM,
+        })
     except TPDBRateLimited as e:
         logging.warning(f"TPDB challenge/rate-limit for {item_id}: {e}")
         return jsonify({'error': str(e), 'error_type': 'tpdb_rate_limited'}), 429
     except Exception as e:
         logging.error(f"Error getting posters for {item_id}: {e}")
         return jsonify({'error': str(e)}), 500
+
 
 @app.route('/item/<item_id>/select', methods=['POST'])
 def select_poster(item_id):
@@ -531,11 +648,18 @@ def select_poster(item_id):
 
     data = request.get_json() or {}
     poster_url = data.get('poster_url')
-    if not poster_url:
-        return jsonify({'error': 'No poster URL provided'}), 400
+    selection = data.get('selection')
+    clear_selection = bool(data.get('clear_selection'))
+    if clear_selection:
+        user_sessions[session_id]['selections'].pop(item_id, None)
+        logging.info(f"Poster selection cleared for item {item_id}")
+        return jsonify({'success': True, 'cleared': True})
 
-    user_sessions[session_id]['selections'][item_id] = poster_url
-    logging.info(f"Poster selected for item {item_id}: {poster_url}")
+    if not poster_url and not selection:
+        return jsonify({'error': 'No poster selection provided'}), 400
+
+    user_sessions[session_id]['selections'][item_id] = selection or poster_url
+    logging.info(f"Poster selected for item {item_id}")
 
     return jsonify({'success': True})
 
@@ -555,7 +679,7 @@ def upload_poster(item_id):
     if item_id not in selections:
         return jsonify({'error': 'No poster selected for this item'}), 400
 
-    poster_url = selections[item_id]
+    selection = selections[item_id]
 
     items = user_sessions[session_id]['items']
     item = next((i for i in items if i['id'] == item_id), None)
@@ -563,36 +687,16 @@ def upload_poster(item_id):
         return jsonify({'error': 'Item not found'}), 404
 
     try:
-        os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
-        _sweep_stale_temp_posters()
-        safe_title = "".join(c for c in item['title'] if c.isalnum() or c in " _-").rstrip()
-        save_path = os.path.join(Config.TEMP_POSTER_DIR, f"manual_{safe_title}_{item_id}.jpg")
+        result = _upload_selection_to_jellyfin(item, selection, operation='manual-upload')
+        if result['success']:
+            return jsonify(result)
 
-        logging.info(f"Downloading poster for {item['title']}: {poster_url}")
-
-        if download_image_with_cookies(poster_url, save_path):
-            logging.info(f"Uploading poster to Jellyfin for {item['title']}")
-            success = upload_image_to_jellyfin_improved(item_id, save_path)
-
-            try:
-                if os.path.exists(save_path):
-                    os.remove(save_path)
-            except Exception:
-                pass
-
-            if success:
-                _log_processed_item(item, operation='manual-upload', poster_url=poster_url)
-                return jsonify({'success': True})
-            else:
-                _log_failed_item(item, 'Failed to upload to Jellyfin', operation='manual-upload', poster_url=poster_url)
-                return jsonify({'error': 'Failed to upload to Jellyfin'}), 500
-        else:
-            _log_failed_item(item, 'Failed to download poster', operation='manual-upload', poster_url=poster_url)
-            return jsonify({'error': 'Failed to download poster'}), 500
+        error = result.get('error') or 'Failed to upload to Jellyfin'
+        return jsonify({'error': error, **result}), 500
 
     except Exception as e:
         logging.error(f"Error uploading poster for {item_id}: {e}")
-        _log_failed_item(item, e, operation='manual-upload', poster_url=poster_url, item_id=item_id)
+        _log_failed_item(item, e, operation='manual-upload', item_id=item_id)
         return jsonify({'error': str(e)}), 500
 
 @app.route('/upload-all', methods=['POST'])
@@ -615,48 +719,27 @@ def upload_all_selected():
     os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
     _sweep_stale_temp_posters()
 
-    for item_id, poster_url in selections.items():
+    for item_id, selection in selections.items():
         item = None
         try:
             item = next((i for i in items if i['id'] == item_id), None)
             if not item:
-                _log_failed_item(error='Item not found', operation='batch-upload', poster_url=poster_url, item_id=item_id)
+                _log_failed_item(error='Item not found', operation='batch-upload', item_id=item_id)
                 results.append({'item_id': item_id, 'success': False, 'error': 'Item not found'})
                 continue
 
-            safe_title = "".join(c for c in item['title'] if c.isalnum() or c in " _-").rstrip()
-            save_path = os.path.join(Config.TEMP_POSTER_DIR, f"manual_{safe_title}_{item_id}.jpg")
-
-            if download_image_with_cookies(poster_url, save_path):
-                success = upload_image_to_jellyfin_improved(item_id, save_path)
-                try:
-                    if os.path.exists(save_path):
-                        os.remove(save_path)
-                except Exception:
-                    pass
-
-                result = {
-                    'item_id': item_id,
-                    'item_title': item['title'],
-                    'success': success,
-                    'error': None if success else 'Upload failed'
-                }
-                results.append(result)
-                if success:
-                    _log_processed_item(item, operation='batch-upload', poster_url=poster_url)
-                else:
-                    _log_failed_item(item, result['error'], operation='batch-upload', poster_url=poster_url)
-            else:
-                _log_failed_item(item, 'Download failed', operation='batch-upload', poster_url=poster_url)
-                results.append({
-                    'item_id': item_id,
-                    'item_title': item['title'],
-                    'success': False,
-                    'error': 'Download failed'
-                })
+            upload_result = _upload_selection_to_jellyfin(item, selection, operation='batch-upload')
+            results.append({
+                'item_id': item_id,
+                'item_title': item['title'],
+                'success': upload_result['success'],
+                'error': upload_result.get('error'),
+                'poster_url': upload_result.get('poster_url'),
+                'season_results': upload_result.get('season_results', []),
+            })
 
         except Exception as e:
-            _log_failed_item(item, e, operation='batch-upload', poster_url=poster_url, item_id=item_id)
+            _log_failed_item(item, e, operation='batch-upload', item_id=item_id)
             results.append({
                 'item_id': item_id,
                 'item_title': item.get('title', 'Unknown') if item else 'Unknown',
@@ -831,7 +914,71 @@ def _select_auto_batch_target_items(all_items, target_filter, skip_processed=Fal
     return target_items
 
 
-def _run_auto_batch_job(job_id, target_filter, skip_processed=False):
+def _auto_search_and_upload_item(item, include_season_posters=False, replace_existing_season_posters=False):
+    item_id = item.get('id')
+    item_title = item.get('title', 'Unknown')
+    item_type = item.get('type')
+    old_poster_url = item.get('thumbnail_url')
+
+    if include_season_posters and item_type == 'Series':
+        eligible_seasons = get_jellyfin_seasons(item_id)
+        search_result = search_tpdb_for_poster_groups(
+            item_title,
+            item_year=item.get('year'),
+            item_type=item_type,
+            tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
+            eligible_seasons=eligible_seasons,
+            max_posters=1,
+            include_base64=False,
+        )
+        group = search_result.get('best_group')
+        if not group:
+            raise ValueError('No posters found')
+
+        selection = _selection_from_poster_group(
+            group,
+            replace_existing_season_posters=replace_existing_season_posters,
+        )
+        if not selection.get('series_poster_url') and not selection.get('season_posters'):
+            raise ValueError('No eligible posters found')
+
+        upload_result = _upload_selection_to_jellyfin(item, selection, operation='auto-poster')
+        return {
+            'item_id': item_id,
+            'item_title': item_title,
+            'success': upload_result['success'],
+            'error': upload_result.get('error'),
+            'old_poster_url': old_poster_url,
+            'poster_url': upload_result.get('poster_url'),
+            'season_results': upload_result.get('season_results', []),
+            'season_posters_uploaded': len([season for season in upload_result.get('season_results', []) if season.get('success')]),
+        }
+
+    posters = search_tpdb_for_posters_multiple(
+        item_title,
+        item.get('year'),
+        item_type,
+        tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
+        max_posters=1,
+    )
+    if not posters:
+        raise ValueError('No posters found')
+
+    poster_url = posters[0]['url']
+    result = _upload_selection_to_jellyfin(item, poster_url, operation='auto-poster')
+    return {
+        'item_id': item_id,
+        'item_title': item_title,
+        'success': result['success'],
+        'error': result.get('error'),
+        'old_poster_url': old_poster_url,
+        'poster_url': poster_url,
+        'season_results': [],
+        'season_posters_uploaded': 0,
+    }
+
+
+def _run_auto_batch_job(job_id, target_filter, skip_processed=False, include_season_posters=False, replace_existing_season_posters=False):
     results = []
     successful_count = 0
     failed_count = 0
@@ -917,120 +1064,40 @@ def _run_auto_batch_job(job_id, target_filter, skip_processed=False):
                 )
 
                 logging.info(f"Processing item {i+1}/{total_items}: {item_title}")
-                posters = search_tpdb_for_posters_multiple(
-                    item_title,
-                    item_year,
-                    item_type,
-                    tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
-                    max_posters=1,
+                result = _auto_search_and_upload_item(
+                    item,
+                    include_season_posters=include_season_posters,
+                    replace_existing_season_posters=replace_existing_season_posters,
                 )
 
                 if _is_auto_batch_cancelled(job_id):
                     _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
                     return
-
-                if not posters:
-                    result = {
-                        'item_id': item_id,
-                        'item_title': item_title,
-                        'success': False,
-                        'error': 'No posters found',
-                        'old_poster_url': old_poster_url,
-                        'poster_url': None
-                    }
-                    _log_failed_item(item, result['error'], operation='auto-poster')
-                    results.append(result)
-                    failed_count += 1
-                    _update_auto_batch_job(
-                        job_id,
-                        phase='failed',
-                        processed=i + 1,
-                        failed=failed_count,
-                        results=list(results),
-                        message=f'No posters found for {item_title}.',
-                    )
-                    continue
-
-                poster_url = posters[0]['url']
-                safe_title = "".join(c for c in item_title if c.isalnum() or c in " _-").rstrip()
-                save_path = os.path.join(Config.TEMP_POSTER_DIR, f"auto_{safe_title}_{item_id}.jpg")
 
                 _update_auto_batch_job(
                     job_id,
-                    phase='downloading',
-                    new_poster_url=poster_url,
-                    message=f'Downloading poster for {item_title}...'
+                    phase='applying',
+                    new_poster_url=result.get('poster_url'),
+                    message=f'Applying poster to {item_title}...'
                 )
-                if _is_auto_batch_cancelled(job_id):
-                    _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
-                    return
 
-                if download_image_with_cookies(poster_url, save_path):
-                    _update_auto_batch_job(job_id, phase='applying', message=f'Applying poster to {item_title}...')
-                    if _is_auto_batch_cancelled(job_id):
-                        _finish_auto_batch_cancelled(job_id, results, successful_count, failed_count)
-                        return
-
-                    upload_success = upload_image_to_jellyfin_improved(item_id, save_path)
-
-                    try:
-                        if os.path.exists(save_path):
-                            os.remove(save_path)
-                    except Exception as cleanup_error:
-                        logging.warning(f"Failed to cleanup temp file {save_path}: {cleanup_error}")
-
-                    if upload_success:
-                        _log_processed_item(item, operation='auto-poster', poster_url=poster_url)
-                        result = {
-                            'item_id': item_id,
-                            'item_title': item_title,
-                            'success': True,
-                            'error': None,
-                            'old_poster_url': old_poster_url,
-                            'poster_url': poster_url
-                        }
-                        results.append(result)
-                        successful_count += 1
-                        logging.info(f"Successfully uploaded poster for: {item_title}")
-                        _update_auto_batch_job(
-                            job_id,
-                            phase='applied',
-                            processed=i + 1,
-                            successful=successful_count,
-                            results=list(results),
-                            message=f'Applied poster to {item_title}.',
-                        )
-                    else:
-                        result = {
-                            'item_id': item_id,
-                            'item_title': item_title,
-                            'success': False,
-                            'error': 'Failed to upload to Jellyfin',
-                            'old_poster_url': old_poster_url,
-                            'poster_url': poster_url
-                        }
-                        _log_failed_item(item, result['error'], operation='auto-poster', poster_url=poster_url)
-                        results.append(result)
-                        failed_count += 1
-                        _update_auto_batch_job(
-                            job_id,
-                            phase='failed',
-                            processed=i + 1,
-                            failed=failed_count,
-                            results=list(results),
-                            message=f'Failed to apply poster to {item_title}.',
-                        )
+                results.append(result)
+                if result.get('success'):
+                    successful_count += 1
+                    season_count = result.get('season_posters_uploaded', 0)
+                    message = f'Applied poster to {item_title}.'
+                    if season_count:
+                        message = f'Applied poster and {season_count} season poster(s) to {item_title}.'
+                    logging.info(f"Successfully uploaded poster for: {item_title}")
+                    _update_auto_batch_job(
+                        job_id,
+                        phase='applied',
+                        processed=i + 1,
+                        successful=successful_count,
+                        results=list(results),
+                        message=message,
+                    )
                 else:
-                    result = {
-                        'item_id': item_id,
-                        'item_title': item_title,
-                        'success': False,
-                        'error': 'Failed to download poster',
-                        'old_poster_url': old_poster_url,
-                        'poster_url': poster_url
-                    }
-                    _log_failed_item(item, result['error'], operation='auto-poster', poster_url=poster_url)
-                    results.append(result)
                     failed_count += 1
                     _update_auto_batch_job(
                         job_id,
@@ -1038,8 +1105,29 @@ def _run_auto_batch_job(job_id, target_filter, skip_processed=False):
                         processed=i + 1,
                         failed=failed_count,
                         results=list(results),
-                        message=f'Failed to download poster for {item_title}.',
+                        message=f'Failed to apply poster to {item_title}.',
                     )
+            except ValueError as e:
+                error_message = str(e)
+                result = {
+                    'item_id': item_id,
+                    'item_title': item_title,
+                    'success': False,
+                    'error': error_message,
+                    'old_poster_url': old_poster_url,
+                    'poster_url': None
+                }
+                _log_failed_item(item, error_message, operation='auto-poster')
+                results.append(result)
+                failed_count += 1
+                _update_auto_batch_job(
+                    job_id,
+                    phase='failed',
+                    processed=i + 1,
+                    failed=failed_count,
+                    results=list(results),
+                    message=f'{error_message} for {item_title}.',
+                )
             except TPDBRateLimited as e:
                 rate_limited_error = str(e)
                 logging.warning(f"TPDB rate-limit detected during batch job; aborting early: {rate_limited_error}")
@@ -1125,8 +1213,19 @@ def start_batch_auto_poster():
     data = request.get_json() or {}
     target_filter = data.get('filter', 'no-poster')
     skip_processed = bool(data.get('skip_processed'))
-    job_id = _create_auto_batch_job(target_filter, skip_processed=skip_processed)
-    worker = threading.Thread(target=_run_auto_batch_job, args=(job_id, target_filter, skip_processed), daemon=True)
+    include_season_posters = bool(data.get('include_season_posters'))
+    replace_existing_season_posters = bool(data.get('replace_existing_season_posters'))
+    job_id = _create_auto_batch_job(
+        target_filter,
+        skip_processed=skip_processed,
+        include_season_posters=include_season_posters,
+        replace_existing_season_posters=replace_existing_season_posters,
+    )
+    worker = threading.Thread(
+        target=_run_auto_batch_job,
+        args=(job_id, target_filter, skip_processed, include_season_posters, replace_existing_season_posters),
+        daemon=True,
+    )
     worker.start()
     return jsonify({'success': True, 'job_id': job_id})
 
@@ -1191,6 +1290,9 @@ def batch_auto_poster():
             target_items = [item for item in all_items if item.get('type') == 'Series']
         else:
             target_items = []
+
+        if library_id:
+            target_items = [item for item in target_items if item.get('library_id') == library_id]
 
         if not target_items:
             return jsonify({

--- a/app.py
+++ b/app.py
@@ -640,6 +640,27 @@ def get_item_posters(item_id):
         return jsonify({'error': str(e)}), 500
 
 
+@app.route('/item/<item_id>/season-count')
+def get_item_season_count(item_id):
+    session_id = session.get('session_id')
+    if not session_id or session_id not in user_sessions:
+        return jsonify({'error': 'Session not found'}), 400
+    _touch_session(session_id)
+
+    item = next((i for i in user_sessions[session_id]['items'] if i['id'] == item_id), None)
+    if not item:
+        return jsonify({'error': 'Item not found'}), 404
+    if item.get('type') != 'Series':
+        return jsonify({'season_count': None})
+
+    try:
+        seasons = get_jellyfin_seasons(item_id)
+        return jsonify({'season_count': len(seasons)})
+    except Exception as e:
+        logging.warning(f"Could not get season count for {item.get('title', item_id)}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
 @app.route('/item/<item_id>/select', methods=['POST'])
 def select_poster(item_id):
     """User selects a poster for an item (no upload yet)."""

--- a/app.py
+++ b/app.py
@@ -31,6 +31,8 @@ FAILED_LOG_FILE = getattr(Config, 'FAILED_LOG_FILE', os.path.join(Config.LOG_DIR
 RESULTS_LOG_FILE = getattr(Config, 'RESULTS_LOG_FILE', os.path.join(Config.LOG_DIR, 'results.log'))
 auto_batch_jobs = {}
 auto_batch_jobs_lock = threading.Lock()
+season_count_cache = {}
+season_count_cache_lock = threading.Lock()
 
 
 def _evict_stale_user_sessions(max_age_sec=7200):
@@ -671,8 +673,16 @@ def get_item_season_count(item_id):
         return jsonify({'season_count': None})
 
     try:
+        with season_count_cache_lock:
+            cached_count = season_count_cache.get(item_id)
+        if cached_count is not None:
+            return jsonify({'season_count': cached_count})
+
         seasons = get_jellyfin_seasons(item_id)
-        return jsonify({'season_count': len(seasons)})
+        season_count = len(seasons)
+        with season_count_cache_lock:
+            season_count_cache[item_id] = season_count
+        return jsonify({'season_count': season_count})
     except Exception as e:
         logging.warning(f"Could not get season count for {item.get('title', item_id)}: {e}")
         return jsonify({'error': str(e)}), 500

--- a/app.py
+++ b/app.py
@@ -614,6 +614,7 @@ def get_item_posters(item_id):
         eligible_seasons = get_jellyfin_seasons(item['id']) if item.get('type') == 'Series' else []
         poster_set_limit = request.args.get('set_limit', default=3, type=int)
         poster_set_limit = max(1, min(poster_set_limit or 3, Config.MAX_POSTERS_PER_ITEM))
+        requested_set_url = request.args.get('set_url')
         search_result = search_tpdb_for_poster_groups(
             item['title'],
             item_year=item.get('year'),
@@ -621,6 +622,7 @@ def get_item_posters(item_id):
             tmdb_id=item.get('ProviderIds', {}).get('Tmdb'),
             eligible_seasons=eligible_seasons,
             max_posters=poster_set_limit if item.get('type') == 'Series' else Config.MAX_POSTERS_PER_ITEM,
+            requested_set_urls=[requested_set_url] if requested_set_url else None,
         )
         return jsonify({
             'item': item,

--- a/app.py
+++ b/app.py
@@ -191,7 +191,7 @@ def _write_results_log_entry(entry):
         results_log.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
 
-def _log_processed_item(item=None, operation='auto-poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None):
+def _log_processed_item(item=None, operation='auto-poster', poster_url=None, item_id=None, item_title=None, item_type=None, item_year=None, poster_targets=None, season_results=None):
     """Append one structured successful poster application entry to results.log."""
     try:
         resolved_item = item
@@ -209,6 +209,8 @@ def _log_processed_item(item=None, operation='auto-poster', poster_url=None, ite
             'item_type': resolved_item_type,
             'item_year': resolved_item_year,
             'poster_url': poster_url,
+            'poster_targets': poster_targets or {},
+            'season_results': season_results or [],
         }
         _write_results_log_entry(entry)
         _log_resolved_item(
@@ -421,6 +423,7 @@ def _upload_selection_to_jellyfin(item, selection, operation='manual-upload'):
     errors = []
     season_results = []
     uploaded_any = False
+    series_poster_uploaded = False
 
     os.makedirs(Config.TEMP_POSTER_DIR, exist_ok=True)
     _sweep_stale_temp_posters()
@@ -429,7 +432,7 @@ def _upload_selection_to_jellyfin(item, selection, operation='manual-upload'):
         logging.info(f"Uploading poster to Jellyfin for {item_title}")
         if _upload_poster_url_to_jellyfin_item(item_id, primary_url, operation, item_title):
             uploaded_any = True
-            _log_processed_item(item, operation=operation, poster_url=primary_url)
+            series_poster_uploaded = True
         else:
             errors.append('Failed to upload series poster')
             _log_failed_item(item, 'Failed to upload series poster', operation=operation, poster_url=primary_url)
@@ -446,6 +449,20 @@ def _upload_selection_to_jellyfin(item, selection, operation='manual-upload'):
             error = f"Failed to upload {season_title}"
             errors.append(error)
             season_results.append({'season_id': season_id, 'season_title': season_title, 'success': False, 'poster_url': season_url, 'error': error})
+
+    if uploaded_any:
+        successful_seasons = [season for season in season_results if season.get('success')]
+        _log_processed_item(
+            item,
+            operation=operation,
+            poster_url=primary_url,
+            poster_targets={
+                'series_poster': series_poster_uploaded,
+                'season_count': len(successful_seasons),
+                'season_titles': [season.get('season_title') for season in successful_seasons if season.get('season_title')],
+            },
+            season_results=season_results,
+        )
 
     return {
         'success': uploaded_any and not errors,

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -1158,7 +1158,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
             all_items_url = (
                 f"{Config.JELLYFIN_URL}/Items"
                 f"?IncludeItemTypes=Movie,Series&Recursive=true"
-                f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,Type"
+                f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,Type,ChildCount"
                 f"&SortBy={sort_by_param}&SortOrder={sort_order}"
             )
             response = requests.get(all_items_url, headers=headers, timeout=15)
@@ -1180,6 +1180,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
                         "type": "Movie" if item.get('Type') == 'Movie' else "Series",
                         "thumbnail_url": thumbnail_url,
                         "date_created": item.get('DateCreated', ''),
+                        "season_count": item.get('ChildCount') if item.get('Type') == 'Series' else None,
                         'ProviderIds': item.get('ProviderIds', {})
                     })
             # Python-side sort for safety
@@ -1199,7 +1200,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
                 movies_url = (
                     f"{Config.JELLYFIN_URL}/Items"
                     f"?IncludeItemTypes=Movie&Recursive=true"
-                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated"
+                    f"&Fields=Id,Name,ProductionYear,Path,ImageTags,ProviderIds,DateCreated,ChildCount"
                     f"&SortBy={sort_by_param}&SortOrder={sort_order}"
                 )
                 response = requests.get(movies_url, headers=headers, timeout=15)
@@ -1247,6 +1248,7 @@ def get_jellyfin_items(item_type=None, sort_by='name'):
                         "type": "Series",
                         "thumbnail_url": thumbnail_url,
                         "date_created": item.get('DateCreated', ''),
+                        "season_count": item.get('ChildCount'),
                         'ProviderIds': item.get('ProviderIds', {})
                     })
     except Exception as e:

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -455,7 +455,12 @@ def _extract_tpdb_card_metadata(poster_link):
     set_link = card.select_one('a[href*="/set/"]') if card else None
     uploader_link = card.select_one('.uploaded-by a') if card else None
     overlay = card.select_one('.overlay[data-poster-id]') if card else None
+    preview_source = card.select_one('source[srcset], img.tpdb-poster[src]') if card else None
     set_url = _tpdb_absolute_url(set_link.get('href')) if set_link else None
+    preview_href = preview_source.get('srcset') or preview_source.get('src') if preview_source else None
+    if preview_href:
+        preview_href = preview_href.split(',')[0].strip().split(' ')[0]
+    preview_url = _tpdb_absolute_url(preview_href)
     set_id = None
     if set_url:
         match = re.search(r"/set/(\d+)", set_url)
@@ -469,6 +474,7 @@ def _extract_tpdb_card_metadata(poster_link):
         'uploader': uploader_link.get_text(strip=True) if uploader_link else 'Unknown',
         'tpdb_poster_id': overlay.get('data-poster-id') if overlay else None,
         'tpdb_poster_type': overlay.get('data-poster-type') if overlay else None,
+        'preview_url': preview_url,
     }
 
 
@@ -545,11 +551,13 @@ def _tpdb_url_with_query_params(url, **params):
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
 
 
-def _get_tpdb_preview_image(image_url, include_base64):
+def _get_tpdb_preview_image(image_url, include_base64, preview_url=None):
     if not include_base64:
         return None
-    time.sleep(TPDB_IMAGE_PREVIEW_DELAY_SEC)
-    return get_image_as_base64(image_url)
+    image_source = preview_url or image_url
+    if image_source == image_url:
+        time.sleep(TPDB_IMAGE_PREVIEW_DELAY_SEC)
+    return get_image_as_base64(image_source)
 
 
 def _open_tpdb_page_with_delay(url):
@@ -566,10 +574,12 @@ def search_tpdb_for_poster_groups(
     max_posters=18,
     max_groups=6,
     include_base64=True,
+    requested_set_urls=None,
 ):
     """Return grouped TPDB poster candidates plus a flat show-poster list."""
     global selenium_driver
     eligible_seasons = eligible_seasons or []
+    requested_set_urls = set(requested_set_urls or [])
     season_by_key = {
         _season_key_from_jellyfin(season): season
         for season in eligible_seasons
@@ -604,14 +614,21 @@ def search_tpdb_for_poster_groups(
                         return {'posters': [], 'groups': [], 'best_group': None, 'search_query': search_query}
 
                     expected_year = extract_title_year(search_query) or (str(item_year) if item_year else None)
+                    expected_title = strip_title_year(search_query)
+                    expected_title_norm = normalize_title_for_comparison(expected_title)
                     candidate_links = []
+                    year_mismatch_count = 0
                     for index, link in enumerate(search_result_links):
                         try:
                             title_element = link.find(class_="text-truncate") or link.find("span") or link
                             result_title = title_element.get_text(strip=True) if title_element else link.get_text(strip=True)
+                            display_title = format_title_year_spacing(result_title)
                             result_year = extract_title_year(result_title)
+                            result_title_norm = normalize_title_for_comparison(strip_title_year(result_title))
+                            exact_title_match = bool(expected_title_norm and expected_title_norm == result_title_norm)
                             if expected_year and result_year and result_year != expected_year:
-                                logging.info("Skipping TPDB result for '%s' due to year mismatch: %s", search_query, result_title)
+                                year_mismatch_count += 1
+                                logging.debug("Skipping TPDB result for '%s' due to year mismatch: %s", search_query, display_title)
                                 continue
                             item_page_path = link.get('href')
                             target_item_page_url = item_page_path if item_page_path and item_page_path.startswith('http') else (
@@ -620,23 +637,53 @@ def search_tpdb_for_poster_groups(
                             if not target_item_page_url:
                                 continue
                             candidate_links.append({
-                                'title': result_title,
+                                'title': display_title,
                                 'year': result_year,
                                 'score': calculate_title_match_score(search_query, result_title),
+                                'exact_title_match': exact_title_match,
+                                'exact_year_match': exact_title_match and (not expected_year or result_year == expected_year),
                                 'url': target_item_page_url,
                                 'index': index,
                             })
                         except Exception:
                             continue
 
+                    if year_mismatch_count:
+                        logging.debug("Skipped %d TPDB result(s) for '%s' due to year mismatch.", year_mismatch_count, search_query)
+
+                    exact_matches = sorted(
+                        [candidate for candidate in candidate_links if candidate['exact_year_match']],
+                        key=lambda candidate: candidate['index'],
+                    )
                     strong_matches = [candidate for candidate in candidate_links if candidate['score'] >= 0.8]
-                    candidates_to_check = sorted(
+                    fallback_matches = sorted(
                         strong_matches or candidate_links,
                         key=lambda candidate: (-candidate['score'], candidate['index'])
-                    )[:max_groups]
+                    )
+                    if exact_matches:
+                        logging.info(
+                            "Found %d exact TPDB result(s) for '%s'; checking exact matches first.",
+                            len(exact_matches),
+                            search_query,
+                        )
+
+                    queued_candidate_indexes = set()
+                    candidates_to_check = []
+                    for candidate in exact_matches + fallback_matches:
+                        if candidate['index'] in queued_candidate_indexes:
+                            continue
+                        candidates_to_check.append(candidate)
+                        queued_candidate_indexes.add(candidate['index'])
+                        if len(candidates_to_check) >= max_groups:
+                            break
 
                     for candidate in candidates_to_check:
-                        logging.info("Checking TPDB result for '%s': %s (score %.2f)", search_query, candidate['title'], candidate['score'])
+                        logging.info(
+                            "Checking TPDB result for '%s': %s (%d%% match)",
+                            search_query,
+                            candidate['title'],
+                            round(candidate['score'] * 100),
+                        )
                         _open_tpdb_page_with_delay(candidate['url'])
                         current_url = selenium_driver.current_url
                         if _is_login_url(current_url):
@@ -662,19 +709,32 @@ def search_tpdb_for_poster_groups(
                             'eligible_season_count': len(season_by_key),
                             'covered_season_count': 0,
                             'covered_season_keys': [],
+                            'available_sets': [],
                         }
                         discovered_set_urls = []
+                        discovered_set_lookup = {}
 
-                        for poster_link in item_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]:
+                        for poster_link in item_soup.select(ITEM_POSTER_SELECTOR)[:Config.MAX_POSTERS_PER_ITEM]:
                             href = poster_link.get('href')
                             poster_url = _tpdb_absolute_url(href)
                             if not poster_url:
                                 continue
 
                             metadata = _extract_tpdb_card_metadata(poster_link)
-                            if metadata.get('set_url') and metadata['set_url'] not in discovered_set_urls:
-                                discovered_set_urls.append(metadata['set_url'])
-                            base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                            set_url = metadata.get('set_url')
+                            if set_url and set_url not in discovered_set_lookup:
+                                discovered_set_urls.append(set_url)
+                                discovered_set_lookup[set_url] = {
+                                    'set_id': metadata.get('set_id'),
+                                    'set_url': set_url,
+                                    'set_poster_count': metadata.get('set_poster_count'),
+                                    'uploader': metadata.get('uploader') or 'Unknown',
+                                }
+                            if requested_set_urls and set_url not in requested_set_urls:
+                                continue
+                            if not requested_set_urls and set_url and discovered_set_urls.index(set_url) >= max_posters:
+                                continue
+                            base64_image = _get_tpdb_preview_image(poster_url, include_base64, metadata.get('preview_url'))
                             season_key = _extract_tpdb_season_key(poster_link)
                             if season_key and season_key in season_by_key:
                                 season = season_by_key[season_key]
@@ -699,12 +759,17 @@ def search_tpdb_for_poster_groups(
                                 ))
                                 poster_id += 1
 
+                        group['available_sets'] = list(discovered_set_lookup.values())
                         if discovered_set_urls and season_by_key:
+                            set_urls_to_load = [
+                                set_url for set_url in discovered_set_urls
+                                if not requested_set_urls or set_url in requested_set_urls
+                            ][:max_posters]
                             seen_poster_urls = {
                                 poster.get('url')
                                 for poster in group['show_posters'] + group['season_posters']
                             }
-                            for set_url in discovered_set_urls[:max_posters]:
+                            for set_url in set_urls_to_load:
                                 logging.info("Checking TPDB poster set for '%s': %s", search_query, set_url)
                                 _open_tpdb_page_with_delay(set_url)
                                 current_url = selenium_driver.current_url
@@ -729,7 +794,7 @@ def search_tpdb_for_poster_groups(
                                     poster_type = (metadata.get('tpdb_poster_type') or '').lower()
                                     if season_key and season_key in season_by_key:
                                         season = season_by_key[season_key]
-                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64, metadata.get('preview_url'))
                                         group['season_posters'].append(_poster_dict(
                                             poster_id,
                                             poster_url,
@@ -742,7 +807,7 @@ def search_tpdb_for_poster_groups(
                                         poster_id += 1
                                         seen_poster_urls.add(poster_url)
                                     elif poster_type == 'show':
-                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64, metadata.get('preview_url'))
                                         group['show_posters'].append(_poster_dict(
                                             poster_id,
                                             poster_url,
@@ -804,7 +869,7 @@ def search_tpdb_for_poster_groups(
                                     continue
 
                                 metadata = _extract_tpdb_card_metadata(poster_link)
-                                base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                base64_image = _get_tpdb_preview_image(poster_url, include_base64, metadata.get('preview_url'))
                                 group['season_posters'].append(_poster_dict(
                                     poster_id,
                                     poster_url,
@@ -826,6 +891,7 @@ def search_tpdb_for_poster_groups(
                         group['covered_season_count'] = len(covered_keys)
                         if (group['show_posters'] or group['season_posters']) and group not in groups:
                             groups.append(group)
+                            break
 
                     break
             except TPDBSessionExpired:
@@ -847,7 +913,7 @@ def search_tpdb_for_poster_groups(
         posters = []
         if best_group:
             posters = best_group['show_posters'][:max_posters]
-        logging.info(f"Found {len(posters)} poster links; converting to base64 for preview")
+        logging.info(f"Found {len(posters)} poster links.")
         return {
             'posters': posters,
             'groups': groups,
@@ -912,6 +978,16 @@ def extract_title_year(title):
         return None
     year_match = re.search(r'\((\d{4})\)', title)
     return year_match.group(1) if year_match else None
+
+def strip_title_year(title):
+    if not title:
+        return ""
+    return re.sub(r'\s*\(\d{4}\)\s*', ' ', title).strip()
+
+def format_title_year_spacing(title):
+    if not title:
+        return ""
+    return re.sub(r'\s*\((\d{4})\)', r' (\1)', title).strip()
 
 def normalize_title_for_comparison(title):
     if not title:

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -713,6 +713,7 @@ def search_tpdb_for_poster_groups(
                         }
                         discovered_set_urls = []
                         discovered_set_lookup = {}
+                        discovered_set_order = {}
 
                         for poster_link in item_soup.select(ITEM_POSTER_SELECTOR)[:Config.MAX_POSTERS_PER_ITEM]:
                             href = poster_link.get('href')
@@ -723,6 +724,7 @@ def search_tpdb_for_poster_groups(
                             metadata = _extract_tpdb_card_metadata(poster_link)
                             set_url = metadata.get('set_url')
                             if set_url and set_url not in discovered_set_lookup:
+                                discovered_set_order[set_url] = len(discovered_set_urls)
                                 discovered_set_urls.append(set_url)
                                 discovered_set_lookup[set_url] = {
                                     'set_id': metadata.get('set_id'),
@@ -732,7 +734,7 @@ def search_tpdb_for_poster_groups(
                                 }
                             if requested_set_urls and set_url not in requested_set_urls:
                                 continue
-                            if not requested_set_urls and set_url and discovered_set_urls.index(set_url) >= max_posters:
+                            if not requested_set_urls and set_url and discovered_set_order.get(set_url, 0) >= max_posters:
                                 continue
                             base64_image = _get_tpdb_preview_image(poster_url, include_base64, metadata.get('preview_url'))
                             season_key = _extract_tpdb_season_key(poster_link)

--- a/poster_scraper.py
+++ b/poster_scraper.py
@@ -18,7 +18,7 @@ import hashlib
 import base64
 from datetime import datetime
 import threading
-from urllib.parse import quote_plus
+from urllib.parse import parse_qsl, quote_plus, urlencode, urlsplit, urlunsplit
 from config import Config
 import logging
 from requests.exceptions import ChunkedEncodingError, ConnectionError
@@ -29,6 +29,9 @@ selenium_lock = threading.RLock()
 
 SEARCH_RESULT_SELECTOR = "a.btn.btn-dark-lighter.flex-grow-1.text-truncate.py-2.text-left.position-relative"
 ITEM_POSTER_SELECTOR = "a.bg-transparent.border-0.text-white"
+TPDB_PAGE_REQUEST_DELAY_SEC = 1.25
+TPDB_IMAGE_PREVIEW_DELAY_SEC = 0.75
+TPDB_IMAGE_PREVIEW_RETRY_DELAY_SEC = 3
 RATE_LIMIT_MARKERS = (
     "rate limit",
     "too many requests",
@@ -340,33 +343,163 @@ def get_image_as_base64(image_url):
     """
     Download image and convert to base64 data URL for embedding in UI.
     """
-    try:
-        with requests.Session() as session:
-            session.cookies.update(get_selenium_cookies_as_dict())
-            session.headers.update({
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-                "Referer": "https://theposterdb.com/",
-                "Accept": "image/webp,image/apng,image/*,*/*;q=0.8"
-            })
+    for attempt in range(2):
+        try:
+            with requests.Session() as session:
+                session.cookies.update(get_selenium_cookies_as_dict())
+                session.headers.update({
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                    "Referer": "https://theposterdb.com/",
+                    "Accept": "image/webp,image/apng,image/*,*/*;q=0.8"
+                })
 
-            logging.debug(f"Converting image to base64: {image_url}")
-            response = session.get(image_url, timeout=15)
-            response.raise_for_status()
+                logging.debug(f"Converting image to base64: {image_url}")
+                response = session.get(image_url, timeout=15)
+                if response.status_code == 429 and attempt == 0:
+                    logging.warning("TPDB preview image rate limit hit; retrying in %ss.", TPDB_IMAGE_PREVIEW_RETRY_DELAY_SEC)
+                    time.sleep(TPDB_IMAGE_PREVIEW_RETRY_DELAY_SEC)
+                    continue
+                response.raise_for_status()
 
-            image_data = base64.b64encode(response.content).decode('utf-8')
-            content_type = response.headers.get('content-type', 'image/jpeg')
-            return f"data:{content_type};base64,{image_data}"
-    except Exception as e:
-        logging.warning(f"Error converting image to base64: {e}")
+                image_data = base64.b64encode(response.content).decode('utf-8')
+                content_type = response.headers.get('content-type', 'image/jpeg')
+                return f"data:{content_type};base64,{image_data}"
+        except Exception as e:
+            logging.warning(f"Error converting image to base64: {e}")
+            return None
+    return None
+
+
+def _normalize_tpdb_text(value):
+    return re.sub(r"\s+", " ", (value or "")).strip()
+
+
+def _poster_link_text(poster_link):
+    parts = [
+        poster_link.get_text(" ", strip=True),
+        poster_link.get("title", ""),
+        poster_link.get("aria-label", ""),
+        poster_link.get("href", ""),
+    ]
+    current = poster_link.parent
+    for _ in range(3):
+        if not current:
+            break
+        parts.extend([
+            current.get_text(" ", strip=True),
+            current.get("title", ""),
+            current.get("aria-label", ""),
+        ])
+        current = current.parent
+    for image in poster_link.find_all("img"):
+        parts.extend([
+            image.get("alt", ""),
+            image.get("title", ""),
+            image.get("src", ""),
+            image.get("data-src", ""),
+        ])
+    return _normalize_tpdb_text(" ".join(part for part in parts if part))
+
+
+def _extract_tpdb_season_key(poster_link):
+    text = _poster_link_text(poster_link).lower()
+    if re.search(r"\b(specials?|season\s+0|s00)\b", text):
+        return "specials"
+
+    patterns = (
+        r"\bseason[\s._-]*(\d{1,2})\b",
+        r"\bs[\s._-]*(\d{1,2})\b",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            season_number = int(match.group(1))
+            return "specials" if season_number == 0 else str(season_number)
+
+    return None
+
+
+def _season_key_from_jellyfin(season):
+    if season.get("is_special"):
+        return "specials"
+    season_number = season.get("number", season.get("season_number"))
+    if season_number is None:
         return None
+    return str(season_number)
 
-def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None, tmdb_id=None, max_posters=18):
-    """
-    Return up to max_posters poster URLs with base64 data for preview.
-    item_type should be "Movie" or "Series" (Jellyfin item Type).
-    """
-    global selenium_driver
-    # Determine TMDB media type
+
+def _tpdb_absolute_url(href):
+    if not href:
+        return None
+    if href.startswith('http'):
+        return href
+    if href.startswith('/'):
+        return Config.TPDB_BASE_URL + href
+    return None
+
+
+def _poster_card_container(poster_link):
+    current = poster_link
+    for _ in range(6):
+        if not current:
+            return poster_link.parent
+        classes = current.get('class') or []
+        if 'hovereffect' in classes or current.select_one('div.overlay[data-poster-id]'):
+            return current
+        current = current.parent
+    return poster_link.parent
+
+
+def _extract_tpdb_card_metadata(poster_link):
+    card = _poster_card_container(poster_link)
+    set_link = card.select_one('a[href*="/set/"]') if card else None
+    uploader_link = card.select_one('.uploaded-by a') if card else None
+    overlay = card.select_one('.overlay[data-poster-id]') if card else None
+    set_url = _tpdb_absolute_url(set_link.get('href')) if set_link else None
+    set_id = None
+    if set_url:
+        match = re.search(r"/set/(\d+)", set_url)
+        if match:
+            set_id = match.group(1)
+
+    return {
+        'set_id': set_id,
+        'set_url': set_url,
+        'set_poster_count': set_link.get_text(strip=True) if set_link else None,
+        'uploader': uploader_link.get_text(strip=True) if uploader_link else 'Unknown',
+        'tpdb_poster_id': overlay.get('data-poster-id') if overlay else None,
+        'tpdb_poster_type': overlay.get('data-poster-type') if overlay else None,
+    }
+
+
+def _poster_dict(poster_id, poster_url, base64_image=None, target_type="series", season=None, group_id=None, metadata=None):
+    metadata = metadata or {}
+    poster = {
+        'id': poster_id,
+        'url': poster_url,
+        'base64': base64_image,
+        'title': 'Poster',
+        'uploader': metadata.get('uploader') or 'Unknown',
+        'likes': 0,
+        'target_type': target_type,
+        'group_id': group_id,
+        'set_id': metadata.get('set_id'),
+        'set_url': metadata.get('set_url'),
+        'set_poster_count': metadata.get('set_poster_count'),
+        'tpdb_poster_id': metadata.get('tpdb_poster_id'),
+    }
+    if season:
+        poster.update({
+            'season_id': season.get('id'),
+            'season_number': season.get('number'),
+            'season_title': season.get('title'),
+            'is_special': season.get('is_special', False),
+            'season_has_poster': season.get('has_poster', False),
+        })
+    return poster
+
+
+def _resolve_tpdb_search_query(item_title, item_type=None, tmdb_id=None):
     tmdb_type = None
     if item_type == "Movie":
         tmdb_type = "movie"
@@ -374,8 +507,6 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
         tmdb_type = "tv"
 
     search_query = item_title
-
-    # Prefer TMDB title + year if available
     if tmdb_id and tmdb_type:
         try:
             tmdb_response = requests.get(
@@ -384,33 +515,73 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
             )
             tmdb_response.raise_for_status()
             tmdb_data = tmdb_response.json()
-
             if tmdb_type == "tv":
                 tmdb_title = tmdb_data.get("name")
                 year = (tmdb_data.get("first_air_date") or "")[:4]
             else:
                 tmdb_title = tmdb_data.get("title")
                 year = (tmdb_data.get("release_date") or "")[:4]
-
             if tmdb_title:
                 search_query = f'{tmdb_title} ({year})' if year else tmdb_title
                 logging.info(f"Using TMDB title for TPDB search: {search_query}")
         except Exception as e:
             logging.warning(f"TMDB lookup failed for {item_title} ({item_type}): {e}; falling back to Jellyfin title.")
+    return search_query
 
-    encoded_query = quote_plus(search_query)
-    search_url = Config.TPDB_SEARCH_URL_TEMPLATE.format(query=encoded_query)
 
-    # Optional section narrowing
+def _build_tpdb_search_url(search_query, item_type=None):
+    search_url = Config.TPDB_SEARCH_URL_TEMPLATE.format(query=quote_plus(search_query))
     if item_type == "Movie":
         search_url += "&section=movies"
     elif item_type == "Series":
         search_url += "&section=shows"
+    return search_url
 
+
+def _tpdb_url_with_query_params(url, **params):
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query.update({key: str(value) for key, value in params.items() if value is not None})
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+def _get_tpdb_preview_image(image_url, include_base64):
+    if not include_base64:
+        return None
+    time.sleep(TPDB_IMAGE_PREVIEW_DELAY_SEC)
+    return get_image_as_base64(image_url)
+
+
+def _open_tpdb_page_with_delay(url):
+    time.sleep(TPDB_PAGE_REQUEST_DELAY_SEC)
+    selenium_driver.get(url)
+
+
+def search_tpdb_for_poster_groups(
+    item_title,
+    item_year=None,
+    item_type=None,
+    tmdb_id=None,
+    eligible_seasons=None,
+    max_posters=18,
+    max_groups=6,
+    include_base64=True,
+):
+    """Return grouped TPDB poster candidates plus a flat show-poster list."""
+    global selenium_driver
+    eligible_seasons = eligible_seasons or []
+    season_by_key = {
+        _season_key_from_jellyfin(season): season
+        for season in eligible_seasons
+        if _season_key_from_jellyfin(season)
+    }
+    search_query = _resolve_tpdb_search_query(item_title, item_type=item_type, tmdb_id=tmdb_id)
+    search_url = _build_tpdb_search_url(search_query, item_type=item_type)
     logging.info(f"TPDB search URL: {search_url}")
 
     try:
-        poster_urls = []
+        groups = []
+        poster_id = 1
         for attempt in range(3):
             try:
                 with selenium_lock:
@@ -430,7 +601,7 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
                     search_result_links = soup.select(SEARCH_RESULT_SELECTOR)
                     if not search_result_links:
                         logging.info(f"No TPDB search results for '{search_query}'.")
-                        return []
+                        return {'posters': [], 'groups': [], 'best_group': None, 'search_query': search_query}
 
                     expected_year = extract_title_year(search_query) or (str(item_year) if item_year else None)
                     candidate_links = []
@@ -440,96 +611,223 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
                             result_title = title_element.get_text(strip=True) if title_element else link.get_text(strip=True)
                             result_year = extract_title_year(result_title)
                             if expected_year and result_year and result_year != expected_year:
-                                logging.info(
-                                    "Skipping TPDB result for '%s' due to year mismatch: %s",
-                                    search_query,
-                                    result_title,
-                                )
+                                logging.info("Skipping TPDB result for '%s' due to year mismatch: %s", search_query, result_title)
                                 continue
-                            score = calculate_title_match_score(search_query, result_title)
                             item_page_path = link.get('href')
-                            if not item_page_path:
-                                continue
-                            target_item_page_url = item_page_path if item_page_path.startswith('http') else (
-                                Config.TPDB_BASE_URL + item_page_path if item_page_path.startswith('/') else None
+                            target_item_page_url = item_page_path if item_page_path and item_page_path.startswith('http') else (
+                                Config.TPDB_BASE_URL + item_page_path if item_page_path and item_page_path.startswith('/') else None
                             )
                             if not target_item_page_url:
                                 continue
                             candidate_links.append({
                                 'title': result_title,
                                 'year': result_year,
-                                'score': score,
+                                'score': calculate_title_match_score(search_query, result_title),
                                 'url': target_item_page_url,
                                 'index': index,
                             })
                         except Exception:
                             continue
 
-                    if not candidate_links:
-                        return []
-
                     strong_matches = [candidate for candidate in candidate_links if candidate['score'] >= 0.8]
-                    candidates_to_check = strong_matches or candidate_links
                     candidates_to_check = sorted(
-                        candidates_to_check,
+                        strong_matches or candidate_links,
                         key=lambda candidate: (-candidate['score'], candidate['index'])
-                    )
+                    )[:max_groups]
 
-                    poster_urls = []
                     for candidate in candidates_to_check:
-                        logging.info(
-                            "Checking TPDB result for '%s': %s (score %.2f)",
-                            search_query,
-                            candidate['title'],
-                            candidate['score'],
-                        )
-                        selenium_driver.get(candidate['url'])
+                        logging.info("Checking TPDB result for '%s': %s (score %.2f)", search_query, candidate['title'], candidate['score'])
+                        _open_tpdb_page_with_delay(candidate['url'])
                         current_url = selenium_driver.current_url
                         if _is_login_url(current_url):
                             logging.warning("TPDB session expired on item page for '%s' (%s).", item_title, current_url)
                             raise TPDBSessionExpired("TPDB session expired while loading item page.")
 
                         _raise_if_rate_limited(selenium_driver.page_source, current_url, "item_page")
-
                         try:
                             _wait_for_item_posters_ready(selenium_driver, timeout=15)
                         except TimeoutError:
-                            logging.warning(
-                                "Timed out checking TPDB result '%s' for '%s'; trying next result.",
-                                candidate['title'],
-                                search_query,
-                            )
+                            logging.warning("Timed out checking TPDB result '%s' for '%s'; trying next result.", candidate['title'], search_query)
                             continue
 
                         item_soup = BeautifulSoup(selenium_driver.page_source, 'html.parser')
-                        poster_links = item_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]
-                        for poster_link in poster_links:
+                        group = {
+                            'id': f"group-{candidate['index']}",
+                            'title': candidate['title'],
+                            'url': candidate['url'],
+                            'match_score': candidate['score'],
+                            'source_index': candidate['index'],
+                            'show_posters': [],
+                            'season_posters': [],
+                            'eligible_season_count': len(season_by_key),
+                            'covered_season_count': 0,
+                            'covered_season_keys': [],
+                        }
+                        discovered_set_urls = []
+
+                        for poster_link in item_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]:
                             href = poster_link.get('href')
-                            if not href:
+                            poster_url = _tpdb_absolute_url(href)
+                            if not poster_url:
                                 continue
-                            if href.startswith('http'):
-                                poster_url = href
-                            elif href.startswith('/'):
-                                poster_url = Config.TPDB_BASE_URL + href
-                            else:
-                                continue
-                            poster_urls.append(poster_url)
 
-                        if poster_urls:
-                            logging.info(
-                                "Using TPDB result '%s' for '%s' with %d poster(s).",
-                                candidate['title'],
-                                search_query,
-                                len(poster_urls),
-                            )
-                            break
+                            metadata = _extract_tpdb_card_metadata(poster_link)
+                            if metadata.get('set_url') and metadata['set_url'] not in discovered_set_urls:
+                                discovered_set_urls.append(metadata['set_url'])
+                            base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                            season_key = _extract_tpdb_season_key(poster_link)
+                            if season_key and season_key in season_by_key:
+                                season = season_by_key[season_key]
+                                group['season_posters'].append(_poster_dict(
+                                    poster_id,
+                                    poster_url,
+                                    base64_image=base64_image,
+                                    target_type='season',
+                                    season=season,
+                                    group_id=group['id'],
+                                    metadata=metadata,
+                                ))
+                                poster_id += 1
+                            elif not season_key:
+                                group['show_posters'].append(_poster_dict(
+                                    poster_id,
+                                    poster_url,
+                                    base64_image=base64_image,
+                                    target_type='series',
+                                    group_id=group['id'],
+                                    metadata=metadata,
+                                ))
+                                poster_id += 1
 
-                        logging.info(
-                            "TPDB result '%s' for '%s' had no posters; trying next result.",
-                            candidate['title'],
-                            search_query,
+                        if discovered_set_urls and season_by_key:
+                            seen_poster_urls = {
+                                poster.get('url')
+                                for poster in group['show_posters'] + group['season_posters']
+                            }
+                            for set_url in discovered_set_urls[:max_posters]:
+                                logging.info("Checking TPDB poster set for '%s': %s", search_query, set_url)
+                                _open_tpdb_page_with_delay(set_url)
+                                current_url = selenium_driver.current_url
+                                if _is_login_url(current_url):
+                                    logging.warning("TPDB session expired on set page for '%s' (%s).", item_title, current_url)
+                                    raise TPDBSessionExpired("TPDB session expired while loading set page.")
+
+                                _raise_if_rate_limited(selenium_driver.page_source, current_url, "set_page")
+                                try:
+                                    _wait_for_item_posters_ready(selenium_driver, timeout=10)
+                                except TimeoutError:
+                                    continue
+
+                                set_soup = BeautifulSoup(selenium_driver.page_source, 'html.parser')
+                                for poster_link in set_soup.select(ITEM_POSTER_SELECTOR)[:max(max_posters * max(len(season_by_key) + 1, 1), max_posters)]:
+                                    poster_url = _tpdb_absolute_url(poster_link.get('href'))
+                                    if not poster_url or poster_url in seen_poster_urls:
+                                        continue
+
+                                    metadata = _extract_tpdb_card_metadata(poster_link)
+                                    season_key = _extract_tpdb_season_key(poster_link)
+                                    poster_type = (metadata.get('tpdb_poster_type') or '').lower()
+                                    if season_key and season_key in season_by_key:
+                                        season = season_by_key[season_key]
+                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                        group['season_posters'].append(_poster_dict(
+                                            poster_id,
+                                            poster_url,
+                                            base64_image=base64_image,
+                                            target_type='season',
+                                            season=season,
+                                            group_id=group['id'],
+                                            metadata=metadata,
+                                        ))
+                                        poster_id += 1
+                                        seen_poster_urls.add(poster_url)
+                                    elif poster_type == 'show':
+                                        base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                        group['show_posters'].append(_poster_dict(
+                                            poster_id,
+                                            poster_url,
+                                            base64_image=base64_image,
+                                            target_type='series',
+                                            group_id=group['id'],
+                                            metadata=metadata,
+                                        ))
+                                        poster_id += 1
+                                        seen_poster_urls.add(poster_url)
+
+                        should_fallback_to_season_pages = season_by_key and (
+                            not discovered_set_urls or not group['season_posters']
                         )
-                break
+                        if should_fallback_to_season_pages:
+                            logging.info(
+                                "No usable TPDB set season posters found for '%s'; falling back to season-filtered pages.",
+                                search_query,
+                            )
+
+                        for season_key, season in (season_by_key.items() if should_fallback_to_season_pages else []):
+                            season_param = 0 if season_key == "specials" else season_key
+                            season_url = _tpdb_url_with_query_params(
+                                candidate['url'],
+                                textless="All",
+                                language="all",
+                                season=season_param,
+                                sort="Downloads",
+                                variation="orig",
+                            )
+                            logging.info(
+                                "Checking TPDB season posters for '%s': %s season %s",
+                                search_query,
+                                candidate['title'],
+                                season_param,
+                            )
+                            _open_tpdb_page_with_delay(season_url)
+                            current_url = selenium_driver.current_url
+                            if _is_login_url(current_url):
+                                logging.warning("TPDB session expired on season page for '%s' (%s).", item_title, current_url)
+                                raise TPDBSessionExpired("TPDB session expired while loading season page.")
+
+                            _raise_if_rate_limited(selenium_driver.page_source, current_url, "season_page")
+                            try:
+                                _wait_for_item_posters_ready(selenium_driver, timeout=10)
+                            except TimeoutError:
+                                continue
+
+                            season_soup = BeautifulSoup(selenium_driver.page_source, 'html.parser')
+                            seen_season_urls = {
+                                poster.get('url')
+                                for poster in group['season_posters']
+                                if _season_key_from_jellyfin(poster) == season_key
+                            }
+                            for poster_link in season_soup.select(ITEM_POSTER_SELECTOR)[:max_posters]:
+                                href = poster_link.get('href')
+                                poster_url = _tpdb_absolute_url(href)
+                                if not poster_url or poster_url in seen_season_urls:
+                                    continue
+
+                                metadata = _extract_tpdb_card_metadata(poster_link)
+                                base64_image = _get_tpdb_preview_image(poster_url, include_base64)
+                                group['season_posters'].append(_poster_dict(
+                                    poster_id,
+                                    poster_url,
+                                    base64_image=base64_image,
+                                    target_type='season',
+                                    season=season,
+                                    group_id=group['id'],
+                                    metadata=metadata,
+                                ))
+                                seen_season_urls.add(poster_url)
+                                poster_id += 1
+
+                        covered_keys = {
+                            _season_key_from_jellyfin(poster)
+                            for poster in group['season_posters']
+                            if _season_key_from_jellyfin(poster)
+                        }
+                        group['covered_season_keys'] = sorted(covered_keys)
+                        group['covered_season_count'] = len(covered_keys)
+                        if (group['show_posters'] or group['season_posters']) and group not in groups:
+                            groups.append(group)
+
+                    break
             except TPDBSessionExpired:
                 if attempt == 0:
                     logging.warning("TPDB session expired; re-authenticating and retrying once for '%s'.", item_title)
@@ -538,35 +836,45 @@ def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None,
                 raise
             except TPDBRateLimited:
                 if attempt < 2:
-                    # A short backoff can help when TPDB serves an interstitial challenge page.
                     backoff_sec = 2 + attempt * 2
                     logging.warning("TPDB challenge/rate-limit detected for '%s'; retrying in %ss.", item_title, backoff_sec)
                     time.sleep(backoff_sec)
                     continue
                 raise
 
-        logging.info(f"Found {len(poster_urls)} poster links; converting to base64 for preview")
-        poster_data = []
-        for i, poster_url in enumerate(poster_urls):
-            base64_image = get_image_as_base64(poster_url)
-            poster_data.append({
-                'id': i + 1,
-                'url': poster_url,
-                'base64': base64_image,
-                # Keep fields for future use, but UI won't render them
-                'title': 'Poster',
-                'uploader': 'Unknown',
-                'likes': 0
-            })
-
-        return poster_data
+        groups = sorted(groups, key=lambda group: (-group['covered_season_count'], -group['match_score'], group['source_index']))
+        best_group = groups[0] if groups else None
+        posters = []
+        if best_group:
+            posters = best_group['show_posters'][:max_posters]
+        logging.info(f"Found {len(posters)} poster links; converting to base64 for preview")
+        return {
+            'posters': posters,
+            'groups': groups,
+            'best_group': best_group,
+            'search_query': search_query,
+        }
     except Exception:
-        logging.exception(
-            "Error during TPDB scraping: search_url=%s current_url=%s",
-            search_url,
-            _get_selenium_current_url(),
-        )
+        logging.exception("Error during TPDB scraping: search_url=%s current_url=%s", search_url, _get_selenium_current_url())
         raise
+
+
+def search_tpdb_for_posters_multiple(item_title, item_year=None, item_type=None, tmdb_id=None, max_posters=18):
+    """
+    Return up to max_posters show/movie poster URLs with base64 data for preview.
+    item_type should be "Movie" or "Series" (Jellyfin item Type).
+    """
+    result = search_tpdb_for_poster_groups(
+        item_title,
+        item_year=item_year,
+        item_type=item_type,
+        tmdb_id=tmdb_id,
+        eligible_seasons=[],
+        max_posters=max_posters,
+        max_groups=6,
+        include_base64=True,
+    )
+    return result.get('posters', [])
 
 def extract_poster_metadata(poster_element):
     try:
@@ -665,6 +973,68 @@ def upload_image_to_jellyfin_improved(item_id, image_path):
         # Clean up memory
         if 'encoded_data' in locals():
             del encoded_data
+
+
+def _parse_jellyfin_datetime(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00')).replace(tzinfo=None)
+    except Exception:
+        return None
+
+
+def get_jellyfin_seasons(series_id):
+    """Return eligible Jellyfin seasons for a Series item, including Specials unless future-dated."""
+    if not Config.JELLYFIN_URL or not Config.JELLYFIN_API_KEY or not series_id:
+        return []
+
+    headers = {
+        "X-Emby-Token": Config.JELLYFIN_API_KEY,
+        "Accept": "application/json",
+    }
+    seasons_url = (
+        f"{Config.JELLYFIN_URL}/Shows/{series_id}/Seasons"
+        "?Fields=Id,Name,IndexNumber,PremiereDate,ImageTags"
+    )
+    try:
+        response = requests.get(seasons_url, headers=headers, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+        seasons = []
+        now = datetime.utcnow()
+        for season in data.get('Items', []):
+            premiere_date = _parse_jellyfin_datetime(season.get('PremiereDate'))
+            if premiere_date and premiere_date > now:
+                continue
+
+            season_id = season.get('Id')
+            if not season_id:
+                continue
+
+            season_number = season.get('IndexNumber')
+            has_primary = bool(season.get('ImageTags', {}).get('Primary'))
+            thumbnail_url = None
+            if has_primary:
+                thumbnail_url = (
+                    f"{Config.JELLYFIN_URL}/Items/{season_id}/Images/Primary"
+                    f"?maxWidth=300&quality=85&tag={season['ImageTags']['Primary']}"
+                )
+
+            seasons.append({
+                'id': season_id,
+                'title': season.get('Name') or ('Specials' if season_number == 0 else f"Season {season_number}"),
+                'number': season_number,
+                'is_special': season_number == 0,
+                'premiere_date': season.get('PremiereDate'),
+                'has_poster': has_primary,
+                'thumbnail_url': thumbnail_url,
+            })
+        return seasons
+    except Exception as e:
+        logging.warning(f"Could not fetch seasons for Jellyfin series {series_id}: {e}")
+        return []
+
 
 def get_jellyfin_server_info():
     try:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -143,6 +143,9 @@ body {
 .poster-card:hover { transform: translateY(-5px); box-shadow: var(--box-shadow-hover); border-color: var(--primary-color); }
 .poster-card:hover .poster-image { transform: scale(1.03); }
 .poster-card.selected { border: 3px solid var(--success-color); box-shadow: 0 0 20px rgba(40, 167, 69, 0.3); }
+.poster-group { border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 1rem; background: var(--surface-muted); }
+.poster-group-header { border-bottom: 1px solid var(--border-color); padding-bottom: 0.75rem; }
+.poster-target-label { padding: 0.35rem 0.5rem; font-size: 0.8rem; color: var(--muted-color); text-align: center; border-top: 1px solid var(--border-color); }
 
 /* Dropdown menu */
 .dropdown-menu { z-index: 1060; background: var(--surface); color: var(--app-text); border: 1px solid var(--border-color); }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -153,6 +153,8 @@ body {
 .dropdown-menu { z-index: 1060; background: var(--surface); color: var(--app-text); border: 1px solid var(--border-color); }
 .dropdown-item { color: var(--app-text); }
 .dropdown-item:hover, .dropdown-item:focus { background: var(--surface-muted); color: var(--app-text); }
+.auto-batch-settings-menu { min-width: 240px; }
+.auto-batch-settings-menu .form-check-label { color: var(--app-text); }
 
 /* Alerts */
 .alert { border: none; border-radius: var(--border-radius); padding: 1rem 1.5rem; margin-bottom: 1rem; border-left: 4px solid; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -110,12 +110,12 @@ body {
     color: #fff;
 }
 
-/* Auto-batch progress */
-.auto-batch-progress {
+/* Automatic-batch */
+.automatic-batch-progress {
     border-top: 1px solid var(--border-color);
     padding-top: 1rem;
 }
-.auto-batch-current-preview {
+.automatic-batch-current-preview {
     align-items: center;
     background: var(--surface-muted);
     border: 1px solid var(--border-color);
@@ -127,7 +127,12 @@ body {
     overflow: hidden;
     width: 42px;
 }
-.auto-batch-current-preview img { height: 100%; object-fit: cover; width: 100%; }
+.automatic-batch-current-preview img { height: 100%; object-fit: cover; width: 100%; }
+
+.automatic-batch-row { position: relative; z-index: 20; }
+.automatic-batch-card { position: relative; }
+.automatic-batch-settings-menu { min-width: 240px; }
+.automatic-batch-settings-menu .form-check-label { color: var(--app-text); }
 
 /* Modals */
 .modal-dialog { max-width: 1200px; }
@@ -153,9 +158,6 @@ body {
 .dropdown-menu { z-index: 1060; background: var(--surface); color: var(--app-text); border: 1px solid var(--border-color); }
 .dropdown-item { color: var(--app-text); }
 .dropdown-item:hover, .dropdown-item:focus { background: var(--surface-muted); color: var(--app-text); }
-.auto-batch-settings-menu { min-width: 240px; }
-.auto-batch-settings-menu .form-check-label { color: var(--app-text); }
-.auto-batch-card { position: relative; z-index: 20; }
 
 /* Alerts */
 .alert { border: none; border-radius: var(--border-radius); padding: 1rem 1.5rem; margin-bottom: 1rem; border-left: 4px solid; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -145,6 +145,8 @@ body {
 .poster-card.selected { border: 3px solid var(--success-color); box-shadow: 0 0 20px rgba(40, 167, 69, 0.3); }
 .poster-group { border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 1rem; background: var(--surface-muted); }
 .poster-group-header { border-bottom: 1px solid var(--border-color); padding-bottom: 0.75rem; }
+.poster-set-browser-list { display: grid; gap: 0.5rem; }
+.poster-set-browser-row { border: 1px solid var(--border-color); border-radius: 6px; padding: 0.75rem; background: var(--surface); }
 .poster-target-label { padding: 0.35rem 0.5rem; font-size: 0.8rem; color: var(--muted-color); text-align: center; border-top: 1px solid var(--border-color); }
 
 /* Dropdown menu */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -155,6 +155,7 @@ body {
 .dropdown-item:hover, .dropdown-item:focus { background: var(--surface-muted); color: var(--app-text); }
 .auto-batch-settings-menu { min-width: 240px; }
 .auto-batch-settings-menu .form-check-label { color: var(--app-text); }
+.auto-batch-card { position: relative; z-index: 20; }
 
 /* Alerts */
 .alert { border: none; border-radius: var(--border-radius); padding: 1rem 1.5rem; margin-bottom: 1rem; border-left: 4px solid; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -86,6 +86,47 @@ function initAutoBatchSeasonSettings() {
     syncReplaceState();
 }
 
+function initSeriesSeasonCounts() {
+    const badges = document.querySelectorAll('[data-season-count-item-id]');
+    if (!badges.length) return;
+
+    const loadSeasonCount = async (badge) => {
+        if (!badge || badge.dataset.loaded === 'true') return;
+        badge.dataset.loaded = 'true';
+
+        try {
+            const response = await fetch(`/item/${encodeURIComponent(badge.dataset.seasonCountItemId)}/season-count`);
+            const data = await response.json();
+            if (!response.ok || data.error || data.season_count === null || data.season_count === undefined) {
+                badge.style.display = 'none';
+                return;
+            }
+
+            const count = Number(data.season_count);
+            const text = badge.querySelector('.season-count-text');
+            if (text) text.textContent = `${count} season${count === 1 ? '' : 's'}`;
+        } catch (error) {
+            console.warn('Could not load season count:', error);
+            badge.style.display = 'none';
+        }
+    };
+
+    if (!('IntersectionObserver' in window)) {
+        badges.forEach(loadSeasonCount);
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (!entry.isIntersecting) return;
+            observer.unobserve(entry.target);
+            loadSeasonCount(entry.target);
+        });
+    }, { rootMargin: '200px' });
+
+    badges.forEach(badge => observer.observe(badge));
+}
+
 // Global Variables
 let currentItemId = null;
 let selectedPosters = {};
@@ -116,6 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const themeBtn = document.getElementById('themeToggle');
     if (themeBtn) themeBtn.addEventListener('click', toggleTheme);
     initAutoBatchSeasonSettings();
+    initSeriesSeasonCounts();
 
     // Modals
     const lm = document.getElementById('loadingModal');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -67,18 +67,18 @@ function initAutoBatchSeasonSettings() {
     const replaceInput = document.getElementById('replaceSeasonPostersAutoBatch');
     if (!includeInput || !replaceInput) return;
 
-    includeInput.checked = localStorage.getItem('jpm_include_season_posters') === 'true';
-    replaceInput.checked = localStorage.getItem('jpm_replace_season_posters') === 'true';
+    const savedIncludeSeasonPosters = localStorage.getItem('jpm_include_season_posters');
+    const savedReplaceSeasonPosters = localStorage.getItem('jpm_replace_season_posters');
+    includeInput.checked = savedIncludeSeasonPosters === 'true';
+    replaceInput.checked = savedReplaceSeasonPosters === null ? true : savedReplaceSeasonPosters === 'true';
 
     const syncReplaceState = () => {
         replaceInput.disabled = !includeInput.checked;
-        if (!includeInput.checked) replaceInput.checked = false;
     };
 
     includeInput.addEventListener('change', () => {
         syncReplaceState();
         localStorage.setItem('jpm_include_season_posters', includeInput.checked ? 'true' : 'false');
-        localStorage.setItem('jpm_replace_season_posters', replaceInput.checked ? 'true' : 'false');
     });
     replaceInput.addEventListener('change', () => {
         localStorage.setItem('jpm_replace_season_posters', replaceInput.checked ? 'true' : 'false');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -192,17 +192,17 @@ function startPosterSearchProgress() {
     const startedAt = Date.now();
     const steps = [
         { at: 0, text: 'Searching TPDB for matching entries...' },
-        { at: 5, text: 'Opening the best TPDB result and reading poster sets...' },
-        { at: 10, text: 'Checking linked TPDB sets for matching season posters...' },
-        { at: 18, text: 'Checking season-specific poster pages when needed...' },
-        { at: 25, text: 'Downloading poster previews for the picker...' },
+        { at: 5, text: 'Opening the best match and reading posters...' },
+        { at: 10, text: 'Checking linked sets for matching season posters...' },
+        { at: 18, text: 'Checking season-specific poster pages...' },
+        { at: 25, text: 'Downloading poster previews...' },
         { at: 40, text: 'Still working. TPDB is being checked gently to avoid rate limits...' }
     ];
 
     const update = () => {
         const elapsed = Math.floor((Date.now() - startedAt) / 1000);
         const currentStep = [...steps].reverse().find(step => elapsed >= step.at) || steps[0];
-        if (loadingText) loadingText.textContent = 'Searching TPDB and preparing posters...';
+        if (loadingText) loadingText.textContent = 'Searching for posters...';
         if (loadingSubtext) loadingSubtext.textContent = currentStep.text;
     };
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -62,6 +62,30 @@ function initTheme() {
     }
 }
 
+function initAutoBatchSeasonSettings() {
+    const includeInput = document.getElementById('includeSeasonPostersAutoBatch');
+    const replaceInput = document.getElementById('replaceSeasonPostersAutoBatch');
+    if (!includeInput || !replaceInput) return;
+
+    includeInput.checked = localStorage.getItem('jpm_include_season_posters') === 'true';
+    replaceInput.checked = localStorage.getItem('jpm_replace_season_posters') === 'true';
+
+    const syncReplaceState = () => {
+        replaceInput.disabled = !includeInput.checked;
+        if (!includeInput.checked) replaceInput.checked = false;
+    };
+
+    includeInput.addEventListener('change', () => {
+        syncReplaceState();
+        localStorage.setItem('jpm_include_season_posters', includeInput.checked ? 'true' : 'false');
+        localStorage.setItem('jpm_replace_season_posters', replaceInput.checked ? 'true' : 'false');
+    });
+    replaceInput.addEventListener('change', () => {
+        localStorage.setItem('jpm_replace_season_posters', replaceInput.checked ? 'true' : 'false');
+    });
+    syncReplaceState();
+}
+
 // Global Variables
 let currentItemId = null;
 let selectedPosters = {};
@@ -77,12 +101,20 @@ let currentAutoBatchJobId = null;
 let autoBatchStartedAt = null;
 let manualSelectionVisible = false;
 let posterSearchProgressTimer = null;
+let posterSearchGroups = [];
+let currentPosterSelection = null;
+let currentPosterSearchItem = null;
+let currentPosterEligibleSeasons = [];
+let posterGroupDisplayMode = 'group';
+let currentPosterSetLimit = 3;
+let canBrowseMorePosterSets = false;
 
 document.addEventListener('DOMContentLoaded', function() {
     // Theme first
     initTheme();
     const themeBtn = document.getElementById('themeToggle');
     if (themeBtn) themeBtn.addEventListener('click', toggleTheme);
+    initAutoBatchSeasonSettings();
 
     // Modals
     const lm = document.getElementById('loadingModal');
@@ -159,16 +191,17 @@ function startPosterSearchProgress() {
     const startedAt = Date.now();
     const steps = [
         { at: 0, text: 'Searching TPDB for matching entries...' },
-        { at: 5, text: 'Checking matching TPDB entries for available posters...' },
-        { at: 10, text: 'Trying additional matches if the first result has no posters...' },
-        { at: 15, text: 'Converting poster previews for the picker...' },
-        { at: 25, text: 'Still working. TPDB responses can take a little while...' }
+        { at: 5, text: 'Opening the best TPDB result and reading poster sets...' },
+        { at: 10, text: 'Checking linked TPDB sets for matching season posters...' },
+        { at: 18, text: 'Checking season-specific poster pages when needed...' },
+        { at: 25, text: 'Downloading poster previews for the picker...' },
+        { at: 40, text: 'Still working. TPDB is being checked gently to avoid rate limits...' }
     ];
 
     const update = () => {
         const elapsed = Math.floor((Date.now() - startedAt) / 1000);
         const currentStep = [...steps].reverse().find(step => elapsed >= step.at) || steps[0];
-        if (loadingText) loadingText.textContent = 'Searching and converting posters...';
+        if (loadingText) loadingText.textContent = 'Searching TPDB and preparing posters...';
         if (loadingSubtext) loadingSubtext.textContent = currentStep.text;
     };
 
@@ -187,13 +220,18 @@ function stopPosterSearchProgress() {
 }
 
 // Load posters for item
-async function loadPosters(itemId) {
+async function loadPosters(itemId, setLimit = 3) {
+    if (currentPosterSearchItem?.id !== itemId) {
+        currentPosterSelection = null;
+        posterGroupDisplayMode = 'group';
+    }
     currentItemId = itemId;
+    currentPosterSetLimit = setLimit;
     startPosterSearchProgress();
     if (loadingModal) loadingModal.show();
 
     try {
-        const response = await fetch(`/item/${itemId}/posters`);
+        const response = await fetch(`/item/${itemId}/posters?set_limit=${encodeURIComponent(setLimit)}`);
         const data = await response.json();
 
         if (data.error) {
@@ -201,7 +239,9 @@ async function loadPosters(itemId) {
         }
 
         if (loadingModal) loadingModal.hide();
-        displayPosters(data.item, data.posters);
+        currentPosterSetLimit = data.poster_set_limit || setLimit;
+        canBrowseMorePosterSets = Boolean(data.can_browse_more_sets);
+        displayPosters(data.item, data.posters, data.poster_groups || [], data.eligible_seasons || []);
     } catch (error) {
         console.error('Error loading posters:', error);
         if (loadingModal) loadingModal.hide();
@@ -212,10 +252,25 @@ async function loadPosters(itemId) {
 }
 
 // Display posters in modal (image-only, no author/download box)
-function displayPosters(item, posters) {
+function displayPosters(item, posters, posterGroups = [], eligibleSeasons = []) {
     const modalBody = document.getElementById('posterModalBody');
     const modalTitle = document.querySelector('#posterModal .modal-title');
+    const modalFooter = document.getElementById('posterModalFooter');
+    const previousItemId = currentPosterSearchItem?.id;
     if (modalTitle) modalTitle.innerHTML = `<i class="fas fa-images me-2"></i>Choose Poster for ${item.title}`;
+    if (modalFooter) modalFooter.style.display = 'none';
+    posterSearchGroups = Array.isArray(posterGroups) ? posterGroups : [];
+    if (previousItemId !== item.id) {
+        currentPosterSelection = null;
+        posterGroupDisplayMode = 'group';
+    }
+    currentPosterSearchItem = item;
+    currentPosterEligibleSeasons = Array.isArray(eligibleSeasons) ? eligibleSeasons : [];
+
+    if (item.type === 'Series' && posterSearchGroups.length > 0) {
+        displayPosterGroups(item, posterSearchGroups, currentPosterEligibleSeasons);
+        return;
+    }
 
     if (!posters || posters.length === 0) {
         modalBody.innerHTML = `
@@ -269,6 +324,469 @@ function displayPosters(item, posters) {
     }
 
     if (posterModal) posterModal.show();
+}
+
+function displayPosterGroups(item, groups, eligibleSeasons) {
+    const modalBody = document.getElementById('posterModalBody');
+    const modalFooter = document.getElementById('posterModalFooter');
+    const saveBtn = document.getElementById('savePosterSelectionBtn');
+    const selectionHint = document.getElementById('posterSelectionHint');
+    if (modalFooter) modalFooter.style.display = '';
+    if (saveBtn) saveBtn.disabled = !currentPosterSelection;
+    if (selectionHint) {
+        selectionHint.textContent = currentPosterSelection
+            ? 'Selection saved. Upload it from the item card when you are ready.'
+            : 'Choose posters individually, or use Select Set to pick a whole set.';
+    }
+    let html = `
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+            <div>
+                <h6><i class="fas fa-film me-2"></i>${escapeHtml(item.title)}</h6>
+                <small class="text-muted">${escapeHtml(item.year || 'Unknown Year')} &bull; ${escapeHtml(item.type)}</small>
+                <small class="text-muted ms-3">
+                    <i class="fas fa-layer-group me-1"></i>
+                    Found ${groups.length} TPDB result${groups.length !== 1 ? 's' : ''}
+                </small>
+            </div>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Poster display mode">
+                <button type="button" class="btn btn-outline-secondary poster-group-view-btn ${posterGroupDisplayMode === 'target' ? 'active' : ''}" data-mode="target">
+                    By Target
+                </button>
+                <button type="button" class="btn btn-outline-secondary poster-group-view-btn ${posterGroupDisplayMode === 'group' ? 'active' : ''}" data-mode="group">
+                    By Set
+                </button>
+            </div>
+        </div>
+    `;
+
+    html += posterGroupDisplayMode === 'group'
+        ? renderPosterGroupsByGroup(groups, eligibleSeasons)
+        : renderPosterGroupsByTarget(groups, eligibleSeasons);
+
+    if (canBrowseMorePosterSets) {
+        html += `
+            <div class="text-center mb-3">
+                <button type="button" class="btn btn-outline-primary" id="browseMorePosterSetsBtn">
+                    <i class="fas fa-plus me-1"></i>Browse more sets
+                </button>
+            </div>
+        `;
+    }
+
+    modalBody.innerHTML = html;
+    modalBody.querySelectorAll('.poster-group-view-btn').forEach(button => {
+        button.addEventListener('click', () => setPosterGroupDisplayMode(button.dataset.mode));
+    });
+    modalBody.querySelector('#browseMorePosterSetsBtn')?.addEventListener('click', () => browseMorePosterSets());
+    modalBody.querySelectorAll('.select-poster-group-btn').forEach(button => {
+        button.addEventListener('click', () => selectPosterGroup(button.dataset.groupId));
+    });
+    modalBody.querySelectorAll('.select-poster-set-btn').forEach(button => {
+        button.addEventListener('click', () => selectPosterSet(button.dataset.groupId, Number(button.dataset.setIndex || 0), button.dataset.setId || null));
+    });
+    modalBody.querySelectorAll('.grouped-poster-option').forEach(card => {
+        card.addEventListener('click', () => {
+            if (card.dataset.targetType === 'season') {
+                selectGroupedSeasonPoster(card.dataset.groupId, card.dataset.seasonId, card.dataset.posterId);
+            } else {
+                selectGroupedShowPoster(card.dataset.groupId, card.dataset.posterId);
+            }
+        });
+    });
+
+    if (posterModal) posterModal.show();
+}
+
+function renderPosterGroupsByGroup(groups, eligibleSeasons) {
+    let groupNumber = 1;
+    return groups.map((group) => {
+        const showPosters = group.show_posters || [];
+        const seasonLists = (eligibleSeasons || []).map(season => ({
+            season,
+            posters: (group.season_posters || []).filter(poster => poster.season_id === season.id)
+        }));
+        const allPosters = [
+            ...showPosters,
+            ...seasonLists.flatMap(entry => entry.posters)
+        ];
+        const setIds = [...new Set(allPosters.map(poster => poster.set_id).filter(Boolean))];
+        if (setIds.length) {
+            return setIds.map(setId => {
+                const displayGroupNumber = groupNumber++;
+                const setPosters = [];
+                const showPoster = showPosters.find(poster => poster.set_id === setId);
+                if (showPoster) {
+                    setPosters.push({ poster: showPoster, targetType: 'show' });
+                }
+                seasonLists.forEach(entry => {
+                    const poster = entry.posters.find(currentPoster => currentPoster.set_id === setId);
+                    if (poster) {
+                        setPosters.push({ poster, targetType: 'season' });
+                    }
+                });
+
+                return renderPosterSetSection(group, setPosters, displayGroupNumber, null, setId);
+            }).join('');
+        }
+
+        const setCount = Math.max(
+            showPosters.length,
+            ...seasonLists.map(entry => entry.posters.length),
+            0
+        );
+
+        if (!setCount) return '';
+
+        return Array.from({ length: setCount }, (_, setIndex) => {
+            const displayGroupNumber = groupNumber++;
+            const setPosters = [];
+            if (showPosters[setIndex]) {
+                setPosters.push({ poster: showPosters[setIndex], targetType: 'show' });
+            }
+            seasonLists.forEach(entry => {
+                if (entry.posters[setIndex]) {
+                    setPosters.push({ poster: entry.posters[setIndex], targetType: 'season' });
+                }
+            });
+
+            return renderPosterSetSection(group, setPosters, displayGroupNumber, setIndex, null);
+        }).join('');
+    }).join('');
+}
+
+function renderPosterSetSection(group, setPosters, displayGroupNumber, setIndex = null, setId = null) {
+    const posters = setPosters.map(entry => entry.poster);
+    const uploader = getPosterSetUploader(posters);
+    const setUrl = posters.find(poster => poster.set_url)?.set_url;
+    let html = `
+        <section class="poster-group poster-set-group mb-4">
+            <div class="poster-group-header d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+                <div>
+                    <h6 class="mb-1">Set ${displayGroupNumber}${uploader ? ` <span class="text-muted">(uploader: ${escapeHtml(uploader)})</span>` : ''}</h6>
+                    <small class="text-muted">${setUrl ? `<a href="${escapeHtml(setUrl)}" target="_blank" rel="noopener">TPDB Set</a>` : escapeHtml(group.title || 'TPDB result')}</small>
+                </div>
+                <button type="button" class="btn btn-sm btn-outline-success select-poster-set-btn"
+                    data-group-id="${escapeHtml(group.id)}"
+                    data-set-index="${setIndex ?? ''}"
+                    data-set-id="${escapeHtml(setId || '')}">
+                    <i class="fas fa-check-double me-1"></i>Select Set
+                </button>
+            </div>
+            <div class="row">
+    `;
+
+    setPosters.forEach((entry, posterIndex) => {
+        html += renderGroupedPosterCard(entry.poster, posterIndex, entry.targetType, group.id);
+    });
+
+    return `${html}</div></section>`;
+}
+
+function renderPosterGroupsByTarget(groups, eligibleSeasons) {
+    let html = renderPosterTargetSection(
+        'Series poster',
+        groups.flatMap(group => group.show_posters || []),
+        'show'
+    );
+
+    (eligibleSeasons || []).forEach(season => {
+        const posters = groups.flatMap(group => (group.season_posters || []).filter(poster => poster.season_id === season.id));
+        if (posters.length) {
+            html += renderPosterTargetSection(season.title || 'Season', posters, 'season');
+        }
+    });
+
+    if (!groups.some(group => (group.season_posters || []).length > 0)) {
+        html += `
+            <div class="alert alert-info">
+                No season posters were detected for the eligible seasons.
+            </div>
+        `;
+    }
+
+    return html;
+}
+
+function renderPosterTargetSection(title, posters, targetType) {
+    if (!posters.length) return '';
+    let html = `
+        <section class="poster-group poster-target-section mb-4">
+            <div class="poster-group-header mb-3">
+                <h6 class="mb-0">${escapeHtml(title)}</h6>
+            </div>
+            <div class="row">
+    `;
+    posters.forEach((poster, index) => {
+        html += renderGroupedPosterCard(poster, index, targetType, poster.group_id);
+    });
+    return `${html}</div></section>`;
+}
+
+function getPosterSetUploader(posters) {
+    const posterWithUploader = posters.find(poster => poster.uploader && poster.uploader !== 'Unknown');
+    return posterWithUploader?.uploader || '';
+}
+
+function setPosterGroupDisplayMode(mode) {
+    posterGroupDisplayMode = mode === 'group' ? 'group' : 'target';
+    displayPosterGroups(currentPosterSearchItem, posterSearchGroups, currentPosterEligibleSeasons);
+    applyGroupedSelectionHighlight();
+}
+
+function browseMorePosterSets() {
+    if (!currentItemId) return;
+    loadPosters(currentItemId, currentPosterSetLimit + 3);
+}
+
+function renderGroupedPosterCard(poster, index, targetType, groupId) {
+    const imageSource = poster.base64 || '';
+    const label = targetType === 'season' ? (poster.season_title || 'Season') : 'Series';
+    return `
+        <div class="col-lg-2 col-md-3 col-sm-4 col-6 mb-3">
+            <div class="card poster-card grouped-poster-option h-100"
+                data-poster-id="${escapeHtml(poster.id)}"
+                data-group-id="${escapeHtml(groupId)}"
+                data-target-type="${escapeHtml(targetType)}"
+                data-season-id="${escapeHtml(poster.season_id || '')}">
+                <div class="poster-container">
+                    ${!poster.base64 ? `
+                        <div class="poster-loading d-flex align-items-center justify-content-center">
+                            <div class="text-center">
+                                <i class="fas fa-exclamation-triangle text-warning mb-2"></i>
+                                <br>
+                                <small class="text-muted">Image failed to load</small>
+                            </div>
+                        </div>
+                    ` : ''}
+                    <img src="${imageSource}"
+                        class="card-img-top poster-image"
+                        alt="${escapeHtml(label)} poster ${index + 1}"
+                        loading="lazy"
+                        style="${!poster.base64 ? 'display: none;' : ''}">
+                </div>
+                <div class="poster-target-label">${escapeHtml(label)}</div>
+            </div>
+        </div>
+    `;
+}
+
+function findPosterGroup(groupId) {
+    return posterSearchGroups.find(group => String(group.id) === String(groupId));
+}
+
+function findPosterInGroup(group, posterId, targetType) {
+    const posters = targetType === 'season' ? group.season_posters || [] : group.show_posters || [];
+    return posters.find(poster => String(poster.id) === String(posterId));
+}
+
+function createEmptySeriesPosterSelection() {
+    return {
+        type: 'series_group',
+        series_poster_url: null,
+        season_posters: {}
+    };
+}
+
+function hasCurrentPosterSelection() {
+    return Boolean(
+        currentPosterSelection?.series_poster_url ||
+        Object.keys(currentPosterSelection?.season_posters || {}).length > 0
+    );
+}
+
+function buildSelectionFromGroup(group) {
+    const showPosters = group.show_posters || [];
+    const selection = {
+        type: 'series_group',
+        series_poster_url: showPosters[0]?.url || null,
+        season_posters: {}
+    };
+
+    (group.season_posters || []).forEach(poster => {
+        if (!poster.season_id || selection.season_posters[poster.season_id]) return;
+        selection.season_posters[poster.season_id] = {
+            url: poster.url,
+            title: poster.season_title || 'Season'
+        };
+    });
+
+    return selection;
+}
+
+function buildSelectionFromPosterSet(group, setIndex, setId = null) {
+    const showPosters = group.show_posters || [];
+    if (setId) {
+        const showPoster = showPosters.find(poster => poster.set_id === setId);
+        const selection = {
+            type: 'series_group',
+            series_poster_url: showPoster?.url || null,
+            season_posters: {}
+        };
+
+        (currentPosterEligibleSeasons || []).forEach(season => {
+            const poster = (group.season_posters || []).find(currentPoster => (
+                currentPoster.season_id === season.id && currentPoster.set_id === setId
+            ));
+            if (!poster?.season_id) return;
+            selection.season_posters[poster.season_id] = {
+                url: poster.url,
+                title: poster.season_title || season.title || 'Season'
+            };
+        });
+
+        return selection;
+    }
+
+    const selection = {
+        type: 'series_group',
+        series_poster_url: showPosters[setIndex]?.url || null,
+        season_posters: {}
+    };
+
+    (currentPosterEligibleSeasons || []).forEach(season => {
+        const seasonPosters = (group.season_posters || []).filter(poster => poster.season_id === season.id);
+        const poster = seasonPosters[setIndex];
+        if (!poster?.season_id) return;
+        selection.season_posters[poster.season_id] = {
+            url: poster.url,
+            title: poster.season_title || season.title || 'Season'
+        };
+    });
+
+    return selection;
+}
+
+async function saveCurrentPosterSelection() {
+    if (!hasCurrentPosterSelection()) {
+        await clearCurrentPosterSelection();
+        return;
+    }
+
+    const response = await fetch(`/item/${currentItemId}/select`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ selection: currentPosterSelection })
+    });
+    const data = await response.json();
+    if (!data.success) throw new Error(data.error || 'Failed to select poster');
+
+    selectedPosters[currentItemId] = currentPosterSelection;
+    updateItemStatus(currentItemId, 'selected');
+    updateUploadAllButton();
+    document.getElementById('savePosterSelectionBtn')?.removeAttribute('disabled');
+    const selectionHint = document.getElementById('posterSelectionHint');
+    if (selectionHint) selectionHint.textContent = 'Selection saved. Upload it from the item card when you are ready.';
+}
+
+async function clearCurrentPosterSelection() {
+    const response = await fetch(`/item/${currentItemId}/select`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clear_selection: true })
+    });
+    const data = await response.json();
+    if (!data.success) throw new Error(data.error || 'Failed to clear poster selection');
+
+    currentPosterSelection = null;
+    delete selectedPosters[currentItemId];
+    const statusElement = document.getElementById(`status-${currentItemId}`);
+    const itemCard = document.querySelector(`[data-item-id="${currentItemId}"]`);
+    if (statusElement) statusElement.innerHTML = '';
+    if (itemCard) itemCard.classList.remove('selected');
+    updateUploadAllButton();
+    document.getElementById('savePosterSelectionBtn')?.setAttribute('disabled', 'disabled');
+    const selectionHint = document.getElementById('posterSelectionHint');
+    if (selectionHint) selectionHint.textContent = 'Choose posters individually, or use Select Set to pick a whole set.';
+}
+
+async function selectPosterGroup(groupId) {
+    const group = findPosterGroup(groupId);
+    if (!group) return;
+
+    try {
+        currentPosterSelection = buildSelectionFromGroup(group);
+        await saveCurrentPosterSelection();
+        applyGroupedSelectionHighlight();
+    } catch (error) {
+        console.error('Error selecting poster set:', error);
+        showAlert('Failed to select poster set: ' + error.message, 'danger');
+    }
+}
+
+async function selectPosterSet(groupId, setIndex, setId = null) {
+    const group = findPosterGroup(groupId);
+    if (!group) return;
+
+    try {
+        currentPosterSelection = buildSelectionFromPosterSet(group, setIndex, setId);
+        await saveCurrentPosterSelection();
+        applyGroupedSelectionHighlight();
+    } catch (error) {
+        console.error('Error selecting poster set:', error);
+        showAlert('Failed to select poster set: ' + error.message, 'danger');
+    }
+}
+
+async function selectGroupedShowPoster(groupId, posterId) {
+    const group = findPosterGroup(groupId);
+    const poster = group ? findPosterInGroup(group, posterId, 'show') : null;
+    if (!group || !poster) return;
+
+    try {
+        currentPosterSelection = currentPosterSelection || createEmptySeriesPosterSelection();
+        currentPosterSelection.series_poster_url =
+            currentPosterSelection.series_poster_url === poster.url ? null : poster.url;
+        await saveCurrentPosterSelection();
+        applyGroupedSelectionHighlight();
+    } catch (error) {
+        console.error('Error selecting series poster:', error);
+        showAlert('Failed to select series poster: ' + error.message, 'danger');
+    }
+}
+
+async function selectGroupedSeasonPoster(groupId, seasonId, posterId) {
+    const group = findPosterGroup(groupId);
+    const poster = group ? findPosterInGroup(group, posterId, 'season') : null;
+    if (!group || !poster || !seasonId) return;
+
+    try {
+        currentPosterSelection = currentPosterSelection || createEmptySeriesPosterSelection();
+        if (currentPosterSelection.season_posters[seasonId]?.url === poster.url) {
+            delete currentPosterSelection.season_posters[seasonId];
+        } else {
+            currentPosterSelection.season_posters[seasonId] = {
+                url: poster.url,
+                title: poster.season_title || 'Season'
+            };
+        }
+        await saveCurrentPosterSelection();
+        applyGroupedSelectionHighlight();
+    } catch (error) {
+        console.error('Error selecting season poster:', error);
+        showAlert('Failed to select season poster: ' + error.message, 'danger');
+    }
+}
+
+function applyGroupedSelectionHighlight() {
+    document.querySelectorAll('.grouped-poster-option').forEach(card => {
+        const group = findPosterGroup(card.dataset.groupId);
+        const poster = group ? findPosterInGroup(group, card.dataset.posterId, card.dataset.targetType) : null;
+        let selected = false;
+        if (poster && card.dataset.targetType === 'show') {
+            selected = currentPosterSelection?.series_poster_url === poster.url;
+        } else if (poster && card.dataset.targetType === 'season') {
+            selected = currentPosterSelection?.season_posters?.[poster.season_id]?.url === poster.url;
+        }
+        card.classList.toggle('selected', selected);
+    });
+}
+
+function finishPosterSelection() {
+    if (!currentPosterSelection) {
+        showAlert('Choose a poster before saving.', 'warning');
+        return;
+    }
+    if (posterModal) posterModal.hide();
 }
 
 // Select a poster (store selection server-side; no immediate upload)
@@ -622,6 +1140,11 @@ function escapeHtml(value) {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+}
+
+function cssEscapeValue(value) {
+    if (window.CSS && typeof CSS.escape === 'function') return CSS.escape(String(value));
+    return String(value).replace(/["\\]/g, '\\$&');
 }
 
 function formatOperationLabel(operation) {
@@ -1123,9 +1646,16 @@ async function startAutoBatchPoster(filter) {
             'series': 'Automatically find and upload posters for all Series?'
         }[filter] || 'Start automatic poster upload?';
         const skipProcessed = Boolean(document.getElementById('skipProcessedAutoBatch')?.checked);
-        const fullConfirmText = skipProcessed ?
-            `${confirmText}\n\nAlready processed items in results.log will be skipped.` :
-            confirmText;
+        const includeSeasonPosters = Boolean(document.getElementById('includeSeasonPostersAutoBatch')?.checked);
+        const replaceSeasonPosters = Boolean(document.getElementById('replaceSeasonPostersAutoBatch')?.checked);
+        const confirmNotes = [];
+        if (skipProcessed) confirmNotes.push('Already processed items in results.log will be skipped.');
+        if (includeSeasonPosters) {
+            confirmNotes.push(replaceSeasonPosters ?
+                'Season posters will be included and existing season posters may be replaced.' :
+                'Season posters will be included only when a season is missing a poster.');
+        }
+        const fullConfirmText = confirmNotes.length ? `${confirmText}\n\n${confirmNotes.join('\n')}` : confirmText;
 
         if (!confirm(fullConfirmText)) return;
 
@@ -1150,7 +1680,12 @@ async function startAutoBatchPoster(filter) {
         const resp = await fetch('/batch-auto-poster/start', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ filter, skip_processed: skipProcessed })
+            body: JSON.stringify({
+                filter,
+                skip_processed: skipProcessed,
+                include_season_posters: includeSeasonPosters,
+                replace_existing_season_posters: replaceSeasonPosters
+            })
         });
 
         const data = await resp.json();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1430,6 +1430,29 @@ async function loadProcessedItems() {
     }
 }
 
+function formatProcessedItemTooltip(detail) {
+    const timestamp = formatLogTimestamp(detail.timestamp);
+    const targets = detail.poster_targets || {};
+    const parts = [];
+
+    if (targets.series_poster) {
+        parts.push('Series poster');
+    } else if (detail.item_type === 'Movie' || detail.poster_url) {
+        parts.push(detail.item_type === 'Movie' ? 'Movie poster' : 'Primary poster');
+    }
+
+    const seasonTitles = Array.isArray(targets.season_titles) ? targets.season_titles.filter(Boolean) : [];
+    if (seasonTitles.length) {
+        parts.push(`Season posters: ${seasonTitles.join(', ')}`);
+    } else if (Number(targets.season_count || 0) > 0) {
+        const seasonCount = Number(targets.season_count);
+        parts.push(`${seasonCount} season poster${seasonCount === 1 ? '' : 's'}`);
+    }
+
+    const targetSummary = parts.length ? parts.join('\n') : 'Poster processed';
+    return `${targetSummary}\nProcessed ${timestamp}`;
+}
+
 function applyProcessedItemMarkers(itemDetails) {
     document.querySelectorAll('.item-card-wrapper').forEach(wrapper => {
         const itemId = wrapper.getAttribute('data-item-id');
@@ -1449,7 +1472,7 @@ function applyProcessedItemMarkers(itemDetails) {
         }
 
         if (isProcessed && overlay) {
-            overlay.title = `Processed ${formatLogTimestamp(detail.timestamp)}`;
+            overlay.title = formatProcessedItemTooltip(detail);
             overlay.innerHTML = '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Processed</span>';
         } else if (!isProcessed && overlay) {
             overlay.remove();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -108,6 +108,7 @@ let currentPosterEligibleSeasons = [];
 let posterGroupDisplayMode = 'group';
 let currentPosterSetLimit = 3;
 let canBrowseMorePosterSets = false;
+let loadingPosterSetUrls = new Set();
 
 document.addEventListener('DOMContentLoaded', function() {
     // Theme first
@@ -224,6 +225,7 @@ async function loadPosters(itemId, setLimit = 3) {
     if (currentPosterSearchItem?.id !== itemId) {
         currentPosterSelection = null;
         posterGroupDisplayMode = 'group';
+        loadingPosterSetUrls = new Set();
     }
     currentItemId = itemId;
     currentPosterSetLimit = setLimit;
@@ -263,6 +265,7 @@ function displayPosters(item, posters, posterGroups = [], eligibleSeasons = []) 
     if (previousItemId !== item.id) {
         currentPosterSelection = null;
         posterGroupDisplayMode = 'group';
+        loadingPosterSetUrls = new Set();
     }
     currentPosterSearchItem = item;
     currentPosterEligibleSeasons = Array.isArray(eligibleSeasons) ? eligibleSeasons : [];
@@ -363,21 +366,13 @@ function displayPosterGroups(item, groups, eligibleSeasons) {
         ? renderPosterGroupsByGroup(groups, eligibleSeasons)
         : renderPosterGroupsByTarget(groups, eligibleSeasons);
 
-    if (canBrowseMorePosterSets) {
-        html += `
-            <div class="text-center mb-3">
-                <button type="button" class="btn btn-outline-primary" id="browseMorePosterSetsBtn">
-                    <i class="fas fa-plus me-1"></i>Browse more sets
-                </button>
-            </div>
-        `;
-    }
-
     modalBody.innerHTML = html;
     modalBody.querySelectorAll('.poster-group-view-btn').forEach(button => {
         button.addEventListener('click', () => setPosterGroupDisplayMode(button.dataset.mode));
     });
-    modalBody.querySelector('#browseMorePosterSetsBtn')?.addEventListener('click', () => browseMorePosterSets());
+    modalBody.querySelectorAll('.load-poster-set-btn').forEach(button => {
+        button.addEventListener('click', () => loadPosterSet(button.dataset.setUrl));
+    });
     modalBody.querySelectorAll('.select-poster-group-btn').forEach(button => {
         button.addEventListener('click', () => selectPosterGroup(button.dataset.groupId));
     });
@@ -410,8 +405,9 @@ function renderPosterGroupsByGroup(groups, eligibleSeasons) {
             ...seasonLists.flatMap(entry => entry.posters)
         ];
         const setIds = [...new Set(allPosters.map(poster => poster.set_id).filter(Boolean))];
+        let html = '';
         if (setIds.length) {
-            return setIds.map(setId => {
+            html += setIds.map(setId => {
                 const displayGroupNumber = groupNumber++;
                 const setPosters = [];
                 const showPoster = showPosters.find(poster => poster.set_id === setId);
@@ -427,6 +423,8 @@ function renderPosterGroupsByGroup(groups, eligibleSeasons) {
 
                 return renderPosterSetSection(group, setPosters, displayGroupNumber, null, setId);
             }).join('');
+            html += renderUnloadedPosterSets(group, setIds);
+            return html;
         }
 
         const setCount = Math.max(
@@ -435,9 +433,9 @@ function renderPosterGroupsByGroup(groups, eligibleSeasons) {
             0
         );
 
-        if (!setCount) return '';
+        if (!setCount) return renderUnloadedPosterSets(group, setIds);
 
-        return Array.from({ length: setCount }, (_, setIndex) => {
+        html += Array.from({ length: setCount }, (_, setIndex) => {
             const displayGroupNumber = groupNumber++;
             const setPosters = [];
             if (showPosters[setIndex]) {
@@ -451,7 +449,50 @@ function renderPosterGroupsByGroup(groups, eligibleSeasons) {
 
             return renderPosterSetSection(group, setPosters, displayGroupNumber, setIndex, null);
         }).join('');
+        html += renderUnloadedPosterSets(group, setIds);
+        return html;
     }).join('');
+}
+
+function renderUnloadedPosterSets(group, loadedSetIds = []) {
+    const availableSets = group.available_sets || [];
+    const loadedIds = new Set((loadedSetIds || []).map(String));
+    const unloadedSets = availableSets.filter(setInfo => {
+        if (!setInfo?.set_url) return false;
+        return !loadedIds.has(String(setInfo.set_id || ''));
+    });
+    if (!unloadedSets.length) return '';
+
+    return `
+        <section class="poster-group poster-set-browser mb-4">
+            <div class="poster-group-header mb-3">
+                <h6 class="mb-1">More TPDB Sets</h6>
+                <small class="text-muted">Load individual sets when you want to preview them.</small>
+            </div>
+            <div class="poster-set-browser-list">
+                ${unloadedSets.map(setInfo => {
+                    const isLoading = loadingPosterSetUrls.has(setInfo.set_url);
+                    return `
+                        <div class="poster-set-browser-row d-flex flex-wrap justify-content-between align-items-center gap-2">
+                            <div>
+                                <div class="fw-semibold">${escapeHtml(setInfo.uploader || 'Unknown uploader')}</div>
+                                <small class="text-muted">
+                                    ${escapeHtml(setInfo.set_poster_count || '?')} poster${String(setInfo.set_poster_count || '') === '1' ? '' : 's'}
+                                    &bull;
+                                    <a href="${escapeHtml(setInfo.set_url)}" target="_blank" rel="noopener">TPDB Set</a>
+                                </small>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-primary load-poster-set-btn"
+                                data-set-url="${escapeHtml(setInfo.set_url)}"
+                                ${isLoading ? 'disabled' : ''}>
+                                <i class="fas ${isLoading ? 'fa-spinner fa-spin' : 'fa-plus'} me-1"></i>${isLoading ? 'Loading' : 'Load set'}
+                            </button>
+                        </div>
+                    `;
+                }).join('')}
+            </div>
+        </section>
+    `;
 }
 
 function renderPosterSetSection(group, setPosters, displayGroupNumber, setIndex = null, setId = null) {
@@ -533,9 +574,68 @@ function setPosterGroupDisplayMode(mode) {
     applyGroupedSelectionHighlight();
 }
 
-function browseMorePosterSets() {
-    if (!currentItemId) return;
-    loadPosters(currentItemId, currentPosterSetLimit + 3);
+async function loadPosterSet(setUrl) {
+    if (!currentItemId || !setUrl || loadingPosterSetUrls.has(setUrl)) return;
+    loadingPosterSetUrls.add(setUrl);
+    displayPosterGroups(currentPosterSearchItem, posterSearchGroups, currentPosterEligibleSeasons);
+
+    try {
+        const response = await fetch(`/item/${currentItemId}/posters?set_limit=${encodeURIComponent(currentPosterSetLimit)}&set_url=${encodeURIComponent(setUrl)}`);
+        const data = await response.json();
+        if (data.error) throw new Error(data.error);
+        mergePosterGroups(data.poster_groups || []);
+        canBrowseMorePosterSets = Boolean(data.can_browse_more_sets);
+        displayPosterGroups(currentPosterSearchItem, posterSearchGroups, currentPosterEligibleSeasons);
+        applyGroupedSelectionHighlight();
+    } catch (error) {
+        console.error('Error loading TPDB set:', error);
+        showAlert('Failed to load TPDB set: ' + error.message, 'danger');
+        displayPosterGroups(currentPosterSearchItem, posterSearchGroups, currentPosterEligibleSeasons);
+    } finally {
+        loadingPosterSetUrls.delete(setUrl);
+        displayPosterGroups(currentPosterSearchItem, posterSearchGroups, currentPosterEligibleSeasons);
+        applyGroupedSelectionHighlight();
+    }
+}
+
+function mergePosterGroups(newGroups) {
+    (newGroups || []).forEach(newGroup => {
+        const existingGroup = findPosterGroup(newGroup.id);
+        if (!existingGroup) {
+            posterSearchGroups.push(newGroup);
+            return;
+        }
+
+        existingGroup.show_posters = mergePostersByUrl(existingGroup.show_posters || [], newGroup.show_posters || []);
+        existingGroup.season_posters = mergePostersByUrl(existingGroup.season_posters || [], newGroup.season_posters || []);
+        existingGroup.available_sets = mergeSetsByUrl(existingGroup.available_sets || [], newGroup.available_sets || []);
+        existingGroup.covered_season_count = Math.max(existingGroup.covered_season_count || 0, newGroup.covered_season_count || 0);
+        existingGroup.covered_season_keys = [...new Set([...(existingGroup.covered_season_keys || []), ...(newGroup.covered_season_keys || [])])];
+    });
+}
+
+function mergePostersByUrl(existingPosters, newPosters) {
+    const seenUrls = new Set(existingPosters.map(poster => poster.url));
+    return [
+        ...existingPosters,
+        ...newPosters.filter(poster => {
+            if (!poster?.url || seenUrls.has(poster.url)) return false;
+            seenUrls.add(poster.url);
+            return true;
+        })
+    ];
+}
+
+function mergeSetsByUrl(existingSets, newSets) {
+    const seenUrls = new Set(existingSets.map(setInfo => setInfo.set_url));
+    return [
+        ...existingSets,
+        ...newSets.filter(setInfo => {
+            if (!setInfo?.set_url || seenUrls.has(setInfo.set_url)) return false;
+            seenUrls.add(setInfo.set_url);
+            return true;
+        })
+    ];
 }
 
 function renderGroupedPosterCard(poster, index, targetType, groupId) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,6 +97,9 @@
                     </div>
                     <div class="col-md-4">
                         <div class="d-flex flex-wrap align-items-center justify-content-md-end gap-2">
+                            <button class="btn btn-outline-danger" type="button" id="cancelAutoBatchBtn" onclick="cancelAutoBatch()" style="display: none;">
+                                <i class="fas fa-stop me-1"></i>Cancel
+                            </button>
                             <div class="dropdown">
                                 <button type="button" class="btn btn-outline-primary dropdown-toggle"
                                         data-bs-toggle="dropdown" aria-expanded="false" id="autoPosterBtn" data-bs-boundary="viewport">
@@ -170,34 +173,29 @@
                         </div>
                         <div class="text-end">
                             <small class="text-muted d-block" id="autoBatchProgressCounts">0 / 0</small>
-                            <button class="btn btn-outline-danger btn-sm mt-1" type="button" id="cancelAutoBatchBtn" onclick="cancelAutoBatch()" style="display: none;">
-                                <i class="fas fa-stop me-1"></i>Cancel
-                            </button>
+                            <small class="text-muted d-block mt-1">Estimated time remaining</small>
+                            <strong id="autoBatchEta">Calculating...</strong>
                         </div>
                     </div>
                     <div class="progress">
                         <div id="autoBatchProgressBar" class="progress-bar" role="progressbar" style="width: 0%"></div>
                     </div>
-                    <div class="row text-center mt-2 g-2">
-                        <div class="col-6 col-md-3">
+                    <div class="row row-cols-2 row-cols-md-4 text-center mt-2 g-2">
+                        <div class="col">
                             <small class="text-muted d-block">Remaining</small>
                             <strong id="autoBatchRemaining">0</strong>
                         </div>
-                        <div class="col-6 col-md-3">
+                        <div class="col">
                             <small class="text-muted d-block">Successful</small>
                             <strong class="text-success" id="autoBatchSuccessful">0</strong>
                         </div>
-                        <div class="col-6 col-md-3">
+                        <div class="col">
                             <small class="text-muted d-block">Failed</small>
                             <strong class="text-danger" id="autoBatchFailed">0</strong>
                         </div>
-                        <div class="col-6 col-md-3">
+                        <div class="col">
                             <small class="text-muted d-block">Status</small>
                             <strong id="autoBatchPhase">Starting</strong>
-                        </div>
-                        <div class="col-12 mt-2">
-                            <small class="text-muted d-block">Estimated time remaining</small>
-                            <strong id="autoBatchEta">Calculating...</strong>
                         </div>
                     </div>
                 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -101,6 +101,14 @@
                                 <input class="form-check-input me-2" type="checkbox" role="switch" id="skipProcessedAutoBatch">
                                 <label class="form-check-label small text-muted" for="skipProcessedAutoBatch">Skip already processed</label>
                             </div>
+                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
+                                <input class="form-check-input me-2" type="checkbox" role="switch" id="includeSeasonPostersAutoBatch">
+                                <label class="form-check-label small text-muted" for="includeSeasonPostersAutoBatch">Include season posters</label>
+                            </div>
+                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
+                                <input class="form-check-input me-2" type="checkbox" role="switch" id="replaceSeasonPostersAutoBatch">
+                                <label class="form-check-label small text-muted" for="replaceSeasonPostersAutoBatch">Replace season posters</label>
+                            </div>
                         <div class="dropdown">
                             <button type="button" class="btn btn-outline-primary dropdown-toggle"
                                     data-bs-toggle="dropdown" aria-expanded="false" id="autoPosterBtn" data-bs-boundary="viewport">
@@ -355,6 +363,13 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body" id="posterModalBody"></div>
+            <div class="modal-footer" id="posterModalFooter" style="display:none;">
+                <small class="text-muted me-auto" id="posterSelectionHint">Choose a poster to save it for upload.</small>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="savePosterSelectionBtn" onclick="finishPosterSelection()" disabled>
+                    <i class="fas fa-save me-1"></i>Save Selection
+                </button>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -314,12 +314,23 @@
             </div>
 
             <div class="card-body p-2">
-                <h6 class="card-title text-truncate mb-1" title="{{ item.title }}">
+                <h6 class="card-title text-truncate text-center mb-1" title="{{ item.title }}">
                     {{ item.title }}
                 </h6>
-                {% if item.year %}
-                <small class="text-muted d-block mb-2">
+                {% if item.year or item.type == 'Series' %}
+                <small class="text-muted d-block text-center mb-2">
+                    {% if item.year %}
                     <i class="fas fa-calendar me-1"></i>{{ item.year }}
+                    {% endif %}
+                    {% if item.type == 'Series' and item.season_count is defined and item.season_count is not none %}
+                    {% if item.year %}<span class="mx-1">&bull;</span>{% endif %}
+                    <i class="fas fa-layer-group me-1"></i>{{ item.season_count }} season{{ '' if item.season_count == 1 else 's' }}
+                    {% elif item.type == 'Series' %}
+                    <span class="series-season-count" data-season-count-item-id="{{ item.id }}">
+                        {% if item.year %}<span class="mx-1">&bull;</span>{% endif %}
+                        <i class="fas fa-layer-group me-1"></i><span class="season-count-text">Seasons</span>
+                    </span>
+                    {% endif %}
                 </small>
                 {% endif %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,52 +97,62 @@
                     </div>
                     <div class="col-md-4">
                         <div class="d-flex flex-wrap align-items-center justify-content-md-end gap-2">
-                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
-                                <input class="form-check-input me-2" type="checkbox" role="switch" id="skipProcessedAutoBatch">
-                                <label class="form-check-label small text-muted" for="skipProcessedAutoBatch">Skip already processed</label>
+                            <div class="dropdown">
+                                <button type="button" class="btn btn-outline-primary dropdown-toggle"
+                                        data-bs-toggle="dropdown" aria-expanded="false" id="autoPosterBtn" data-bs-boundary="viewport">
+                                    <i class="fas fa-magic me-1"></i>
+                                    Auto-Get Posters
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    <li>
+                                        <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('no-poster')">
+                                            <i class="fas fa-exclamation-circle me-2 text-warning"></i>
+                                            Items Without Posters
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('all')">
+                                            <i class="fas fa-th me-2 text-primary"></i>
+                                            All Items
+                                        </a>
+                                    </li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li>
+                                        <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('movies')">
+                                            <i class="fas fa-film me-2 text-info"></i>
+                                            Movies Only
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('series')">
+                                            <i class="fas fa-tv me-2 text-success"></i>
+                                            TV Series Only
+                                        </a>
+                                    </li>
+                                </ul>
                             </div>
-                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
-                                <input class="form-check-input me-2" type="checkbox" role="switch" id="includeSeasonPostersAutoBatch">
-                                <label class="form-check-label small text-muted" for="includeSeasonPostersAutoBatch">Include season posters</label>
+                            <div class="dropdown">
+                                <button type="button" class="btn btn-outline-secondary"
+                                        data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false"
+                                        data-bs-boundary="viewport" aria-label="Auto-Get settings">
+                                    <i class="fas fa-sliders-h"></i>
+                                </button>
+                                <div class="dropdown-menu dropdown-menu-end auto-batch-settings-menu p-3">
+                                    <div class="fw-semibold mb-2">Auto-Get Settings</div>
+                                    <div class="form-check form-switch mb-2">
+                                        <input class="form-check-input" type="checkbox" role="switch" id="skipProcessedAutoBatch">
+                                        <label class="form-check-label small" for="skipProcessedAutoBatch">Skip already processed</label>
+                                    </div>
+                                    <div class="form-check form-switch mb-2">
+                                        <input class="form-check-input" type="checkbox" role="switch" id="includeSeasonPostersAutoBatch">
+                                        <label class="form-check-label small" for="includeSeasonPostersAutoBatch">Include season posters</label>
+                                    </div>
+                                    <div class="form-check form-switch mb-0">
+                                        <input class="form-check-input" type="checkbox" role="switch" id="replaceSeasonPostersAutoBatch">
+                                        <label class="form-check-label small" for="replaceSeasonPostersAutoBatch">Replace season posters</label>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="form-check form-switch d-inline-flex align-items-center mb-0">
-                                <input class="form-check-input me-2" type="checkbox" role="switch" id="replaceSeasonPostersAutoBatch">
-                                <label class="form-check-label small text-muted" for="replaceSeasonPostersAutoBatch">Replace season posters</label>
-                            </div>
-                        <div class="dropdown">
-                            <button type="button" class="btn btn-outline-primary dropdown-toggle"
-                                    data-bs-toggle="dropdown" aria-expanded="false" id="autoPosterBtn" data-bs-boundary="viewport">
-                                <i class="fas fa-magic me-1"></i>
-                                Auto-Get Posters
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('no-poster')">
-                                        <i class="fas fa-exclamation-circle me-2 text-warning"></i>
-                                        Items Without Posters
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('all')">
-                                        <i class="fas fa-th me-2 text-primary"></i>
-                                        All Items
-                                    </a>
-                                </li>
-                                <li><hr class="dropdown-divider"></li>
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('movies')">
-                                        <i class="fas fa-film me-2 text-info"></i>
-                                        Movies Only
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="startAutoBatchPoster('series')">
-                                        <i class="fas fa-tv me-2 text-success"></i>
-                                        TV Series Only
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
                         </div>
                     </div>
                 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@
 <!-- Automatic Batch Operations -->
 <div class="row mb-4">
     <div class="col-12">
-        <div class="card" style="position: relative;">
+        <div class="card auto-batch-card">
             <div class="card-body py-3">
                 <div class="row align-items-center">
                     <div class="col-md-8">

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,9 +82,9 @@
 </div>
 
 <!-- Automatic Batch Operations -->
-<div class="row mb-4">
+<div class="row mb-4 automatic-batch-row">
     <div class="col-12">
-        <div class="card auto-batch-card">
+        <div class="card automatic-batch-card">
             <div class="card-body py-3">
                 <div class="row align-items-center">
                     <div class="col-md-8">
@@ -140,7 +140,7 @@
                                         data-bs-boundary="viewport" aria-label="Auto-Get settings">
                                     <i class="fas fa-sliders-h"></i>
                                 </button>
-                                <div class="dropdown-menu dropdown-menu-end auto-batch-settings-menu p-3">
+                                <div class="dropdown-menu dropdown-menu-end automatic-batch-settings-menu p-3">
                                     <div class="fw-semibold mb-2">Auto-Get Settings</div>
                                     <div class="form-check form-switch mb-2">
                                         <input class="form-check-input" type="checkbox" role="switch" id="skipProcessedAutoBatch">
@@ -159,10 +159,10 @@
                         </div>
                     </div>
                 </div>
-                <div id="autoBatchProgressPanel" class="auto-batch-progress mt-3" style="display: none;">
+                <div id="autoBatchProgressPanel" class="automatic-batch-progress mt-3" style="display: none;">
                     <div class="d-flex justify-content-between align-items-center mb-2">
                         <div class="d-flex align-items-center gap-2">
-                            <div class="auto-batch-current-preview">
+                            <div class="automatic-batch-current-preview">
                                 <img id="autoBatchCurrentPoster" alt="Current poster preview" style="display: none;">
                                 <i id="autoBatchCurrentPosterEmpty" class="fas fa-image text-muted"></i>
                             </div>


### PR DESCRIPTION
Builds upon the code from #23

> Tested with 288 series items, 4 failed, 284 successful
> The 4 that failed did indeed not have posters on ThePosterDB.

- Add optional season poster support for Auto-Get and manual poster selection
- Group TPDB results by set, with per-set loading to reduce unnecessary TPDB requests
- Add Series season counts and richer processed-item details on library cards
- Added season-aware processed logging so Series cards can show whether the series poster and/or season posters were updated
- Added lazy Series season count display on library cards
- Added Auto-Get progress improvements, ETA display, and cancel support
- Improved dropdown layout and dark theme styling
- Season counts are loaded lazily and cached during the app session

Using automatic fetching with posters has a possibility of being blocked by Cloudflare, maybe we should include a warning and/or have higher rate limits, and/or allow doing smaller batches by selecting how many to process? I was fine with my size of library however.

<img width="1552" height="1123" alt="seasons" src="https://github.com/user-attachments/assets/729f983a-7127-4950-98d2-7b88c0204e56" />
