### PR TITLE
Add Docker support with configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.venv
+__pycache__
+*.pyc
+.env
+config.py
+data
+cache
+logs
+tests
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    WEB_HOST=0.0.0.0 \
+    WEB_PORT=5001
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium chromium-driver \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/data /app/cache /app/logs
+
+EXPOSE 5001
+VOLUME ["/app/data", "/app/cache", "/app/logs"]
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ python app.py
 
 Visit `http://localhost:5001` in your web browser, or use your configured `WEB_PORT`.
 
+### Docker
+
+Docker images include Chromium for Selenium-based TPDb searches. Create a `.env` file with the required values:
+
+```env
+SECRET_KEY=replace-with-a-long-random-value
+JELLYFIN_URL=https://jellyfin.example.com
+JELLYFIN_API_KEY=your-jellyfin-api-key
+TPDB_EMAIL=you@example.com
+TPDB_PASSWORD=your-tpdb-password
+TMDB_API_KEY=your-tmdb-api-key
+```
+
+Build and start the container with:
+
+```bash
+docker compose up -d --build
+```
+
+Open `http://localhost:5001`.
+
 ### Upgrading an existing installation
 
 1. Stop the old process. Back up `data/` and `logs/` before starting the new version.

--- a/config_example.py
+++ b/config_example.py
@@ -3,31 +3,31 @@ import os
 class Config:
     # Flask Configuration
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
-    DEBUG = False
+    DEBUG = os.environ.get('DEBUG', '').lower() == 'true'
     
     # Jellyfin Configuration
-    JELLYFIN_URL = ""
-    JELLYFIN_API_KEY = ""
+    JELLYFIN_URL = os.environ.get('JELLYFIN_URL', '')
+    JELLYFIN_API_KEY = os.environ.get('JELLYFIN_API_KEY', '')
     
     # TPDb Configuration
     TPDB_BASE_URL = "https://theposterdb.com"
     TPDB_SEARCH_URL_TEMPLATE = "https://theposterdb.com/search?term={query}"
-    TPDB_EMAIL = ""
-    TPDB_PASSWORD = ""
+    TPDB_EMAIL = os.environ.get('TPDB_EMAIL', '')
+    TPDB_PASSWORD = os.environ.get('TPDB_PASSWORD', '')
 
     # TMDB Configuration
-    TMDB_API_KEY = ""
+    TMDB_API_KEY = os.environ.get('TMDB_API_KEY', '')
 
     # Application Settings
-    WEB_HOST = "127.0.0.1"  # Single-user/local by default; do not expose without authentication.
-    WEB_PORT = 5001
+    WEB_HOST = os.environ.get('WEB_HOST', '127.0.0.1')  # Single-user/local by default; do not expose without authentication.
+    WEB_PORT = int(os.environ.get('WEB_PORT', '5001'))
     MAX_POSTERS_PER_ITEM = 18
     MAX_TPDB_SETS_PER_ITEM = 30
-    TPDB_BATCH_DELAY_SEC = 1.5
-    TPDB_DEBUG_SNAPSHOTS = False
-    LOG_DIR = "logs"
-    CACHE_DIR = "cache"
-    APP_STATE_DIR = "data"
+    TPDB_BATCH_DELAY_SEC = float(os.environ.get('TPDB_BATCH_DELAY_SEC', '1.5'))
+    TPDB_DEBUG_SNAPSHOTS = os.environ.get('TPDB_DEBUG_SNAPSHOTS', '').lower() == 'true'
+    LOG_DIR = os.environ.get('LOG_DIR', 'logs')
+    CACHE_DIR = os.environ.get('CACHE_DIR', 'cache')
+    APP_STATE_DIR = os.environ.get('APP_STATE_DIR', 'data')
     TEMP_POSTER_DIR = os.path.join(CACHE_DIR, "temp_posters")
     # These legacy files are imported into APP_STATE_DIR/poster_manager.sqlite3 once.
     # Originals are retained; subsequent state updates go to SQLite.
@@ -36,4 +36,4 @@ class Config:
     PROTECTED_ITEMS_FILE = os.path.join(APP_STATE_DIR, "protected_items.json")
     TPDB_ITEM_MAP_FILE = os.path.join(APP_STATE_DIR, "tpdb_item_map.json")
     # Disposable picker-v2/*.json responses do not contain embedded image data.
-    TPDB_PICKER_CACHE_MAX_AGE_DAYS = 7
+    TPDB_PICKER_CACHE_MAX_AGE_DAYS = int(os.environ.get('TPDB_PICKER_CACHE_MAX_AGE_DAYS', '7'))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  jellyfin-poster-manager:
+    build: .
+    container_name: jellyfin-poster-manager
+    ports:
+      - "5001:5001"
+    environment:
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY}
+      JELLYFIN_URL: ${JELLYFIN_URL:?Set JELLYFIN_URL}
+      JELLYFIN_API_KEY: ${JELLYFIN_API_KEY:?Set JELLYFIN_API_KEY}
+      TPDB_EMAIL: ${TPDB_EMAIL:?Set TPDB_EMAIL}
+      TPDB_PASSWORD: ${TPDB_PASSWORD:?Set TPDB_PASSWORD}
+      TMDB_API_KEY: ${TMDB_API_KEY:-}
+      WEB_HOST: 0.0.0.0
+      WEB_PORT: 5001
+    volumes:
+      - ./data:/app/data
+      - ./cache:/app/cache
+      - ./logs:/app/logs
+    restart: unless-stopped


### PR DESCRIPTION
Added a Docker image with Chromium and ChromeDrive. Includes Docker Compose configuration with persistent volumes for application data, cache, and logs, environment-based configuration, and README instructions for setup and deployment.

Validated with Docker image build and test suite.